### PR TITLE
set defaults for ssh/http access CIDR

### DIFF
--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -3,11 +3,13 @@ variable "network_id" {
 }
 
 variable "http_access_cidr_range" {
-  type = "string"
+  type    = string
+  default = "0.0.0.0/0"
 }
 
 variable "ssh_access_cidr_range" {
-  type = "string"
+  type    = string
+  default = "0.0.0.0/0"
 }
 variable "subnet_id" {
   type = string


### PR DESCRIPTION
Not sure if we want this as a default? If not, Ill change this PR to just unquote `"string"`