### PR TITLE
Fix image versions

### DIFF
--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -15,7 +15,7 @@ variable "subnet_id" {
 
 variable "machine_image" {
   type        = string
-  default     = "projects/sourcegraph-ci/global/images/executor-docker-mirror-d636cd1648-113833"
+  default     = "projects/sourcegraph-ci/global/images/executor-docker-mirror-18d914ef3a-118088"
   description = "Docker registry mirror node machine disk image to use for creating the boot volume."
 }
 

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -19,7 +19,7 @@ variable "resource_prefix" {
 
 variable "machine_image" {
   type        = string
-  default     = "projects/sourcegraph-ci/global/images/executor-a7ce591963-1631546817"
+  default     = "projects/sourcegraph-ci/global/images/executor-7ee53c7624-116846"
   description = "Executor node machine disk image to use for creating the boot volume"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "zone" {
 
 variable "docker_mirror_machine_image" {
   type        = string
-  default     = "ubuntu-os-cloud/ubuntu-1804-bionic-v20200701"
+  default     = "projects/sourcegraph-ci/global/images/executor-docker-mirror-18d914ef3a-118088"
   description = "Docker registry mirror node machine disk image to use for creating the boot volume"
 }
 


### PR DESCRIPTION
The docker registry was just a noop and the executor version was too old for the 3.34 release.