### PR TITLE
release: v3.37.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ This repository provides a [Terraform module](https://learn.hashicorp.com/tutori
 
 This repository provides four submodules:
 
-1. The [executors module](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.0/submodules/executors) provisions compute resources for executors.
-1. The [docker-mirror module](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.0/submodules/docker-mirror) provisions a Docker registry pull-through cache.
-1. The [networking module](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.0/submodules/networking) provisions a network to be shared by the executor and Docker registry resources.
-1. The [credentials module](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.0/submodules/credentials) provisions credentials required by the Sourcegraph instance to enable observability and auto-scaling of executors.
+1. The [executors module](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.1/submodules/executors) provisions compute resources for executors.
+1. The [docker-mirror module](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.1/submodules/docker-mirror) provisions a Docker registry pull-through cache.
+1. The [networking module](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.1/submodules/networking) provisions a network to be shared by the executor and Docker registry resources.
+1. The [credentials module](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.1/submodules/credentials) provisions credentials required by the Sourcegraph instance to enable observability and auto-scaling of executors.
 
-The [multiple-executors example](https://github.com/sourcegraph/terraform-google-executors/blob/v3.37.0/examples/multiple-executors) uses the submodule directly to provision multiple executor resource groups performing different types of work. Follow this example if you are:
+The [multiple-executors example](https://github.com/sourcegraph/terraform-google-executors/blob/v3.37.1/examples/multiple-executors) uses the submodule directly to provision multiple executor resource groups performing different types of work. Follow this example if you are:
 
 1. Provisioning executors for use with multiple features (e.g., both [auto-indexing](https://docs.sourcegraph.com/code_intelligence/explanations/auto_indexing) and [server-side batch changes](https://docs.sourcegraph.com/batch_changes/explanations/server_side)), or
 1. Provisioning resources for multiple Sourcegraph instances (e.g., test, prod)
 
-This repository also provides a [root module](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.0) combining the executors, network, and docker-mirror resources into an easier to use package.
+This repository also provides a [root module](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.1) combining the executors, network, and docker-mirror resources into an easier to use package.
 
-The [single-executor example](https://github.com/sourcegraph/terraform-google-executors/blob/v3.37.0/examples/single-executor) uses the root module to provision a single executor type. Follow this example if you are deploying to a single Sourcegraph instance and using a single executors-backed feature.
+The [single-executor example](https://github.com/sourcegraph/terraform-google-executors/blob/v3.37.1/examples/single-executor) uses the root module to provision a single executor type. Follow this example if you are deploying to a single Sourcegraph instance and using a single executors-backed feature.
 
 ## Requirements
 

--- a/examples/multiple-executors/README.md
+++ b/examples/multiple-executors/README.md
@@ -1,6 +1,6 @@
 # Multiple executor example
 
-This example uses [networking](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.0/submodules/networking), [docker-mirror](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.0/submodules/docker-mirror), and [executors](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.0/submodules/executors) submodules that provision a network, a Docker registry mirror, and sets of resources running one or more types of executors.
+This example uses [networking](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.1/submodules/networking), [docker-mirror](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.1/submodules/docker-mirror), and [executors](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.1/submodules/executors) submodules that provision a network, a Docker registry mirror, and sets of resources running one or more types of executors.
 
 The following variables must be supplied:
 
@@ -10,4 +10,4 @@ The following variables must be supplied:
 
 If your deployment environment already has a Docker registry that can be used, only the `executor` submodule must be used (and references to the `networking` and `docker-mirror` modules can be dropped). The Docker registry mirror address can be supplied along with its containing network and subnetwork as pre-existing identifier literals.
 
-All of these module's variables are defined in [modules/networking/variables.tf](https://github.com/sourcegraph/terraform-google-executors/blob/v3.37.0/modules/networking/variables.tf), [modules/docker-mirror/variables.tf](https://github.com/sourcegraph/terraform-google-executors/blob/v3.37.0/modules/docker-mirror/variables.tf), and [modules/executors/variables.tf](https://github.com/sourcegraph/terraform-google-executors/blob/v3.37.0/modules/executors/variables.tf).
+All of these module's variables are defined in [modules/networking/variables.tf](https://github.com/sourcegraph/terraform-google-executors/blob/v3.37.1/modules/networking/variables.tf), [modules/docker-mirror/variables.tf](https://github.com/sourcegraph/terraform-google-executors/blob/v3.37.1/modules/docker-mirror/variables.tf), and [modules/executors/variables.tf](https://github.com/sourcegraph/terraform-google-executors/blob/v3.37.1/modules/executors/variables.tf).

--- a/examples/multiple-executors/main.tf
+++ b/examples/multiple-executors/main.tf
@@ -1,13 +1,13 @@
 module "networking" {
   source  = "sourcegraph/executors/google//modules/networking"
-  version = "3.37.0" # LATEST
+  version = "3.37.1" # LATEST
 
   region = local.region
 }
 
 module "docker-mirror" {
   source  = "sourcegraph/executors/google//modules/docker-mirror"
-  version = "3.37.0" # LATEST
+  version = "3.37.1" # LATEST
 
   zone                = local.zone
   network_id          = module.networking.network_id
@@ -17,7 +17,7 @@ module "docker-mirror" {
 
 module "executors-codeintel" {
   source  = "sourcegraph/executors/google//modules/executors"
-  version = "3.37.0" # LATEST
+  version = "3.37.1" # LATEST
 
   zone                                = local.zone
   network_id                          = module.networking.network_id
@@ -33,7 +33,7 @@ module "executors-codeintel" {
 
 module "executors-batches" {
   source  = "sourcegraph/executors/google//modules/executors"
-  version = "3.37.0" # LATEST
+  version = "3.37.1" # LATEST
 
   zone                                = local.zone
   network_id                          = module.networking.network_id

--- a/examples/single-executor/README.md
+++ b/examples/single-executor/README.md
@@ -1,6 +1,6 @@
 # Single executor example
 
-This example uses the [root module](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.0) that provisions a network, a Docker registry mirror, and a set of resources to run _one_ type of executor. To provision more than one type of executor (multiple queues or multiple environments), see the following `multiple-executors` example.
+This example uses the [root module](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.1) that provisions a network, a Docker registry mirror, and a set of resources to run _one_ type of executor. To provision more than one type of executor (multiple queues or multiple environments), see the following `multiple-executors` example.
 
 The following variables must be supplied:
 
@@ -12,4 +12,4 @@ The following variables must be supplied:
 - `executor_metrics_environment_label`: The name of the target environment (e.g., `staging`, `prod`). This value must be the same as the `EXECUTOR_METRIC_ENVIRONMENT_LABEL` environment variable as described in [Configuring auto scaling](https://docs.sourcegraph.com/admin/deploy_executors#google).
 - `executor_instance_tag`: Compute instances are tagged by this value by the key `executor_tag`. We recommend this value take the form `{executor_queue_name}-{executor_metrics_environment_label}`. This value must be the same as `INSTANCE_TAG` as described in [Configuring observability](https://docs.sourcegraph.com/admin/deploy_executors#google-1).
 
-All of this module's variables are defined in [variables.tf](https://github.com/sourcegraph/terraform-google-executors/blob/v3.37.0/variables.tf).
+All of this module's variables are defined in [variables.tf](https://github.com/sourcegraph/terraform-google-executors/blob/v3.37.1/variables.tf).

--- a/examples/single-executor/main.tf
+++ b/examples/single-executor/main.tf
@@ -1,6 +1,6 @@
 module "executors" {
   source  = "sourcegraph/executors/google"
-  version = "3.37.0" # LATEST
+  version = "3.37.1" # LATEST
 
   region                                       = local.region
   zone                                         = local.zone

--- a/modules/docker-mirror/README.md
+++ b/modules/docker-mirror/README.md
@@ -2,4 +2,4 @@
 
 This module provides a hosted Docker registry pull-through cache to be used by [Sourcegraph executor](https://docs.sourcegraph.com/admin/executors). It is strongly recommended to deploy a Docker mirror as a cache to reduce rate limiting by the public [Docker Hub registry](https://hub.docker.com/). We have also seen deploying a Docker mirror in the same physical zone as the executors significantly decreased latencies during image pulls.
 
-When using the sibling [executors module](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.0/submodules/executors), the `network_id` and `subnet_id` values must match and the executor module `docker_registry_mirror` value should match `"http://${ip_address}:5000"` (where `ip_address` is this module's output).
+When using the sibling [executors module](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.1/submodules/executors), the `network_id` and `subnet_id` values must match and the executor module `docker_registry_mirror` value should match `"http://${ip_address}:5000"` (where `ip_address` is this module's output).

--- a/modules/executors/README.md
+++ b/modules/executors/README.md
@@ -1,6 +1,6 @@
 # Executors module
 
-This module provides the resources to provision [Sourcegraph executor](https://docs.sourcegraph.com/admin/executors) compute resources on Google Cloud. For a high-level overview of the resources deployed by this module, see the [root module](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.0). This module includes the following resources:
+This module provides the resources to provision [Sourcegraph executor](https://docs.sourcegraph.com/admin/executors) compute resources on Google Cloud. For a high-level overview of the resources deployed by this module, see the [root module](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.1). This module includes the following resources:
 
 - Google compute instance template
 - Google compute group manager, and auto-scaler
@@ -9,4 +9,4 @@ This module provides the resources to provision [Sourcegraph executor](https://d
 
 This module does **not** automatically create networking or Docker mirror resources. The `network_id`, `subnet_id`, and `docker_registry_mirror` variables must be supplied explicitly with resources that have been previously created.
 
-This module is often used with the sibling modules that create [networking](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.0/submodules/networking) and [Docker mirror](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.0/submodules/docker-mirror) resources which can be shared by multiple instances of the executor module (listening to different queues or being deployed in a different environment).
+This module is often used with the sibling modules that create [networking](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.1/submodules/networking) and [Docker mirror](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.1/submodules/docker-mirror) resources which can be shared by multiple instances of the executor module (listening to different queues or being deployed in a different environment).

--- a/modules/networking/README.md
+++ b/modules/networking/README.md
@@ -1,5 +1,5 @@
 # Networking module
 
-This module provides the networking glue between the sibling [executors](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.0/submodules/executors) and [docker-mirror](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.0/submodules/docker-mirror) modules.
+This module provides the networking glue between the sibling [executors](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.1/submodules/executors) and [docker-mirror](https://registry.terraform.io/modules/sourcegraph/executors/google/3.37.1/submodules/docker-mirror) modules.
 
 This module is very simple, creating only a network and a subnet.


### PR DESCRIPTION
`release.sh` looks outdated, so I did a global find & replace (similar to https://github.com/sourcegraph/terraform-google-executors/commit/8580ad2c04554d2f22b8cdfc3c2083649af8b02b). Hopefully I covered everything.