### PR TITLE
Add assign_public_ip flag to executors

### DIFF
--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -60,9 +60,12 @@ resource "google_compute_instance_template" "executor-instance-template" {
   network_interface {
     network    = var.network_id
     subnetwork = var.subnet_id
-    access_config {
-      # I believe this is the default.
-      network_tier = "PREMIUM"
+    dynamic "access_config" {
+      for_each = var.assign_public_ip ? [1] : []
+      content {
+        # I believe this is the default.
+        network_tier = "PREMIUM"
+      }
     }
   }
 

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -137,3 +137,9 @@ variable "docker_registry_mirror" {
   default     = ""
   description = "A URL to a docker registry mirror to use (falling back to docker.io)"
 }
+
+variable "assign_public_ip" {
+  type        = bool
+  default     = true
+  description = "If false, no public IP will be associated with the executors. They cannot be scraped for metrics over the internet if this flag is false."
+}


### PR DESCRIPTION
This is used for executors that are behind a NAT gateway.

### Test plan

Tested with terraform validate that this is valid usage.