### PR TITLE
Allow multiple CIDR’s to be defined in http access range

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,14 +7,14 @@ module "gcp-networking" {
 module "gcp-docker-mirror" {
   source = "./modules/docker-mirror"
 
-  zone                   = var.zone
-  network_id             = module.gcp-networking.network_id
-  subnet_id              = module.gcp-networking.subnet_id
-  machine_image          = var.docker_mirror_machine_image
-  machine_type           = var.docker_mirror_machine_type
-  boot_disk_size         = var.docker_mirror_boot_disk_size
-  http_access_cidr_range = var.docker_mirror_http_access_cidr_range
-  instance_tag_prefix    = var.executor_instance_tag
+  zone                    = var.zone
+  network_id              = module.gcp-networking.network_id
+  subnet_id               = module.gcp-networking.subnet_id
+  machine_image           = var.docker_mirror_machine_image
+  machine_type            = var.docker_mirror_machine_type
+  boot_disk_size          = var.docker_mirror_boot_disk_size
+  http_access_cidr_ranges = var.docker_mirror_http_access_cidr_ranges
+  instance_tag_prefix     = var.executor_instance_tag
 }
 
 module "gcp-executors" {
@@ -29,7 +29,7 @@ module "gcp-executors" {
   boot_disk_size                      = var.executor_boot_disk_size
   preemptible_machines                = var.executor_preemptible_machines
   instance_tag                        = var.executor_instance_tag
-  http_access_cidr_range              = var.executor_http_access_cidr_range
+  http_access_cidr_ranges             = var.executor_http_access_cidr_ranges
   sourcegraph_external_url            = var.executor_sourcegraph_external_url
   sourcegraph_executor_proxy_password = var.executor_sourcegraph_executor_proxy_password
   queue_name                          = var.executor_queue_name

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -57,7 +57,7 @@ resource "google_compute_firewall" "http" {
   network     = var.network_id
   target_tags = ["docker-registry-mirror"]
 
-  source_ranges = [var.http_access_cidr_range]
+  source_ranges = var.http_access_cidr_ranges
 
   # Generally allow ICMP for pings etc.
   allow {
@@ -78,7 +78,7 @@ resource "google_compute_firewall" "http-metrics-access" {
   network     = var.network_id
   target_tags = ["docker-registry-mirror"]
 
-  source_ranges = [var.http_metrics_access_cidr_range]
+  source_ranges = var.http_metrics_access_cidr_ranges
 
   # Expose the debug server port for metrics scraping.
   allow {

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -37,15 +37,15 @@ variable "disk_size" {
   description = "Persistent Docker registry mirror disk size in GB."
 }
 
-variable "http_access_cidr_range" {
-  type        = string
-  default     = "10.0.0.0/16"
+variable "http_access_cidr_ranges" {
+  type        = list(string)
+  default     = ["10.0.0.0/16"]
   description = "CIDR range from where HTTP access to the Docker registry is acceptable."
 }
 
-variable "http_metrics_access_cidr_range" {
-  type        = string
-  default     = "0.0.0.0/0"
+variable "http_metrics_access_cidr_ranges" {
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
   description = "CIDR range from where HTTP access to scrape metrics from the Docker registry is acceptable."
 }
 

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -135,7 +135,7 @@ resource "google_compute_firewall" "executor-http-access" {
   name          = "${local.prefix}executor-http-firewall"
   network       = var.network_id
   target_tags   = ["${local.prefix}executor"]
-  source_ranges = [var.http_access_cidr_range]
+  source_ranges = var.http_access_cidr_range
 
   # Expose the debug server port for metrics scraping.
   allow {

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -135,7 +135,7 @@ resource "google_compute_firewall" "executor-http-access" {
   name          = "${local.prefix}executor-http-firewall"
   network       = var.network_id
   target_tags   = ["${local.prefix}executor"]
-  source_ranges = var.http_access_cidr_range
+  source_ranges = var.http_access_cidr_ranges
 
   # Expose the debug server port for metrics scraping.
   allow {

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -46,7 +46,7 @@ variable "instance_tag" {
   description = "A label tag to add to all the executors; can be used for filtering out the right instances in stackdriver monitoring"
 }
 
-variable "http_access_cidr_range" {
+variable "http_access_cidr_ranges" {
   type        = list(string)
   default     = ["0.0.0.0/0"]
   description = "CIDR range from where HTTP access to the executor instances are acceptable."

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -47,8 +47,8 @@ variable "instance_tag" {
 }
 
 variable "http_access_cidr_range" {
-  type        = string
-  default     = "0.0.0.0/0"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
   description = "CIDR range from where HTTP access to the executor instances are acceptable."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -67,7 +67,7 @@ variable "executor_instance_tag" {
   description = "A label tag to add to all the executors; can be used for filtering out the right instances in stackdriver monitoring"
 }
 
-variable "executor_http_access_cidr_range" {
+variable "executor_http_access_cidr_ranges" {
   type        = list(string)
   default     = ["0.0.0.0/0"]
   description = "CIDR range from where HTTP access to the executor instances are acceptable."

--- a/variables.tf
+++ b/variables.tf
@@ -26,9 +26,9 @@ variable "docker_mirror_boot_disk_size" {
   description = "Docker registry mirror node disk size in GB"
 }
 
-variable "docker_mirror_http_access_cidr_range" {
-  type        = string
-  default     = "10.0.0.0/16"
+variable "docker_mirror_http_access_cidr_ranges" {
+  type        = list(string)
+  default     = ["10.0.0.0/16"]
   description = "CIDR range from where HTTP access to the Docker registry is acceptable."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -68,8 +68,8 @@ variable "executor_instance_tag" {
 }
 
 variable "executor_http_access_cidr_range" {
-  type        = string
-  default     = "0.0.0.0/0"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
   description = "CIDR range from where HTTP access to the executor instances are acceptable."
 }
 


### PR DESCRIPTION
The current `http_access_cidr_range` variable doesn't allow setting multiple CIDR ranges. By switching to a list of strings, we eliminate this restriction.

Error seen before this change:
```
Invalid value for field 'resource.sourceRanges[1]': '34.x.x.x/32,35.x.x.x/32'. Must be a CIDR address range., invalid
```

This is a breaking change if anyone has configured this variable - what's the process here?

### Test plan
Able to plan and apply the changes from https://github.com/sourcegraph/deploy-sourcegraph-managed/pull/337.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
