### PR TITLE
Switch the Checkov step to soft-fail

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -17,3 +17,4 @@ steps:
   - command: .buildkite/ci-checkov.sh
     label: ':lock: security - checkov'    
     agents: { queue: standard }    
+    soft_fail: true


### PR DESCRIPTION
Until we can move to using a pinned Checkov image version – the lack of image
pinning is causing the build step to break unpredictably.

### Test plan

Confirm that the build step no longer fails.