### PR TITLE
Ignogre `target_size` during update

### DIFF
--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -106,6 +106,12 @@ resource "google_compute_instance_group_manager" "executor" {
     minimal_action    = "REPLACE"
     type              = "PROACTIVE"
   }
+
+  lifecycle {
+    ignore_changes = [
+      target_size
+    ]
+  }
 }
 
 resource "google_compute_autoscaler" "executor-autoscaler" {


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group_manager#target_size shouldn't be configured when the instance group is configured with auto scaler

it's annoying to see this during `apply`

```
Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # module.executors.module.executors-batches.google_compute_instance_group_manager.executor has changed
  ~ resource "google_compute_instance_group_manager" "executor" {
        id                        = "projects/sourcegraph-managed-rctest/zones/us-central1-f/instanceGroupManagers/batches--sourcegraph-executor"
        name                      = "batches--sourcegraph-executor"
      ~ target_size               = 1 -> 0
        # (10 unchanged attributes hidden)


        # (2 unchanged blocks hidden)
    }

  # module.executors.module.executors-codeintel.google_compute_instance_group_manager.executor has changed
  ~ resource "google_compute_instance_group_manager" "executor" {
        id                        = "projects/sourcegraph-managed-rctest/zones/us-central1-f/instanceGroupManagers/codeintel--sourcegraph-executor"
        name                      = "codeintel--sourcegraph-executor"
      ~ target_size               = 1 -> 0
        # (10 unchanged attributes hidden)


        # (2 unchanged blocks hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or respond
to these changes.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place
```

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

it works