### PR TITLE
unexpose executor HTTP port due to metrics forwarding

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,10 +10,10 @@ module "gcp-docker-mirror" {
   zone                    = var.zone
   network_id              = module.gcp-networking.network_id
   subnet_id               = module.gcp-networking.subnet_id
+  http_access_cidr_ranges = module.gcp-networking.ip_cidr
   machine_image           = var.docker_mirror_machine_image
   machine_type            = var.docker_mirror_machine_type
   boot_disk_size          = var.docker_mirror_boot_disk_size
-  http_access_cidr_ranges = var.docker_mirror_http_access_cidr_ranges
   instance_tag_prefix     = var.executor_instance_tag
 }
 
@@ -29,7 +29,6 @@ module "gcp-executors" {
   boot_disk_size                           = var.executor_boot_disk_size
   preemptible_machines                     = var.executor_preemptible_machines
   instance_tag                             = var.executor_instance_tag
-  http_access_cidr_ranges                  = var.executor_http_access_cidr_ranges
   sourcegraph_external_url                 = var.executor_sourcegraph_external_url
   sourcegraph_executor_proxy_password      = var.executor_sourcegraph_executor_proxy_password
   queue_name                               = var.executor_queue_name

--- a/modules/credentials/README.md
+++ b/modules/credentials/README.md
@@ -1,7 +1,5 @@
 # Credentials module
 
-This module can be optionally used to create the service account and IAM role resources required to configure auto-scaling and observability of [Sourcegraph executor](https://docs.sourcegraph.com/admin/executors) in Google cloud.
+This module can be optionally used to create the service account and IAM role resources required to configure auto-scaling of [Sourcegraph executor](https://docs.sourcegraph.com/admin/executors) in Google cloud.
 
 Auto-scaling requires that the executor compute instances have permissions to emit metrics to Google Cloud. As outlined in [how to configure auto scaling](https://docs.sourcegraph.com/admin/deploy_executors#google), the Sourcegraph `worker` service must set the `EXECUTOR_METRIC_GOOGLE_APPLICATION_CREDENTIALS_FILE` environment variable to be the same as the `metric_writer_credentials_file` value provided by running this module.
-
-Observability of executor compute resources require that the target Sourcegraph instance's Prometheus have permissions to scrape the executor compute resources. As outlined in [how to configure observability](https://docs.sourcegraph.com/admin/deploy_executors#google-1), the `instance_scraper_credentials_file` value provided by running this module must be supplied to the Sourcegraph Prometheus instance.

--- a/modules/credentials/main.tf
+++ b/modules/credentials/main.tf
@@ -26,25 +26,3 @@ resource "google_project_iam_member" "metric_writer" {
 resource "google_service_account_key" "metric_writer" {
   service_account_id = google_service_account.metric_writer.name
 }
-
-resource "google_service_account" "instance_scraper" {
-  account_id   = "${substr(local.prefix, 0, 11)}-instance-scraper"
-  display_name = "Sourcegraph executors instance scraper"
-}
-
-resource "google_project_iam_custom_role" "instance_scraper" {
-  role_id     = "${substr(var.resource_prefix, 0, 11)}InstanceScraper"
-  title       = "Sourcegraph executors instance scraper"
-  description = "Used to discover running executor instances for metrics scraping in prometheus"
-  permissions = ["compute.instances.list"]
-}
-
-resource "google_project_iam_member" "instance_scraper" {
-  role    = google_project_iam_custom_role.instance_scraper.id
-  member  = "serviceAccount:${google_service_account.instance_scraper.email}"
-  project = data.google_project.project.id
-}
-
-resource "google_service_account_key" "instance_scraper" {
-  service_account_id = google_service_account.instance_scraper.name
-}

--- a/modules/credentials/outputs.tf
+++ b/modules/credentials/outputs.tf
@@ -1,7 +1,3 @@
 output "metric_writer_credentials_file" {
   value = google_service_account_key.metric_writer.private_key
 }
-
-output "instance_scraper_credentials_file" {
-  value = google_service_account_key.instance_scraper.private_key
-}

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -64,27 +64,11 @@ resource "google_compute_firewall" "http" {
     protocol = "icmp"
   }
 
-  # Expose the registry server port.
   allow {
     protocol = "tcp"
     ports = [
-      "5000"
-    ]
-  }
-}
-
-resource "google_compute_firewall" "http-metrics-access" {
-  name        = "sourcegraph-executor-docker-mirror-http-metrics"
-  network     = var.network_id
-  target_tags = ["docker-registry-mirror"]
-
-  source_ranges = var.http_access_cidr_ranges
-
-  # Expose the debug server port for metrics scraping.
-  allow {
-    protocol = "tcp"
-    ports = [
-      "9999" # exporter_exporter
+      "5000", # registry
+      "9999"  # exporter_exporter
     ]
   }
 }

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -43,12 +43,6 @@ variable "http_access_cidr_ranges" {
   description = "CIDR range from where HTTP access to the Docker registry is acceptable."
 }
 
-variable "http_metrics_access_cidr_ranges" {
-  type        = list(string)
-  default     = ["0.0.0.0/0"]
-  description = "DEPRECATED. This is not used anymore."
-}
-
 variable "instance_tag_prefix" {
   type        = string
   description = "A label tag to add to all the machines; can be used for filtering out the right instances in stackdriver monitoring and in Prometheus instance discovery."

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -43,6 +43,12 @@ variable "http_access_cidr_ranges" {
   description = "CIDR range from where HTTP access to the Docker registry is acceptable."
 }
 
+variable "http_metrics_access_cidr_ranges" {
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+  description = "DEPRECATED. This is not used anymore."
+}
+
 variable "instance_tag_prefix" {
   type        = string
   description = "A label tag to add to all the machines; can be used for filtering out the right instances in stackdriver monitoring and in Prometheus instance discovery."

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -60,6 +60,13 @@ resource "google_compute_instance_template" "executor-instance-template" {
   network_interface {
     network    = var.network_id
     subnetwork = var.subnet_id
+    dynamic "access_config" {
+      for_each = var.assign_public_ip ? [1] : []
+      content {
+        # I believe this is the default.
+        network_tier = "PREMIUM"
+      }
+    }
   }
 
   metadata_startup_script = templatefile("${path.module}/startup-script.sh.tpl", {

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -60,13 +60,6 @@ resource "google_compute_instance_template" "executor-instance-template" {
   network_interface {
     network    = var.network_id
     subnetwork = var.subnet_id
-    dynamic "access_config" {
-      for_each = var.assign_public_ip ? [1] : []
-      content {
-        # I believe this is the default.
-        network_tier = "PREMIUM"
-      }
-    }
   }
 
   metadata_startup_script = templatefile("${path.module}/startup-script.sh.tpl", {
@@ -136,21 +129,6 @@ resource "google_compute_autoscaler" "executor-autoscaler" {
       # 1 instance per N queued jobs.
       single_instance_assignment = var.jobs_per_instance_scaling
     }
-  }
-}
-
-resource "google_compute_firewall" "executor-http-access" {
-  name          = "${local.prefix}executor-http-firewall"
-  network       = var.network_id
-  target_tags   = ["${local.prefix}executor"]
-  source_ranges = var.http_access_cidr_ranges
-
-  # Expose the debug server port for metrics scraping.
-  allow {
-    protocol = "tcp"
-    ports = [
-      "9999" # exporter_exporter
-    ]
   }
 }
 

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -155,3 +155,9 @@ variable "docker_registry_mirror_node_exporter_url" {
   default     = ""
   description = "A URL to a docker registry mirror node exporter to scrape (optional)"
 }
+
+variable "assign_public_ip" {
+  type        = bool
+  default     = true
+  description = "If false, no public IP will be associated with the executors. They cannot be scraped for metrics over the internet if this flag is false."
+}

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -46,6 +46,12 @@ variable "instance_tag" {
   description = "A label tag to add to all the executors; can be used for filtering out the right instances in stackdriver monitoring"
 }
 
+variable "http_access_cidr_ranges" {
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+  description = "DEPRECATED. This is not used anymore."
+}
+
 variable "sourcegraph_external_url" {
   type        = string
   description = "The externally accessible URL of the target Sourcegraph instance"

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -46,12 +46,6 @@ variable "instance_tag" {
   description = "A label tag to add to all the executors; can be used for filtering out the right instances in stackdriver monitoring"
 }
 
-variable "http_access_cidr_ranges" {
-  type        = list(string)
-  default     = ["0.0.0.0/0"]
-  description = "CIDR range from where HTTP access to the executor instances are acceptable."
-}
-
 variable "sourcegraph_external_url" {
   type        = string
   description = "The externally accessible URL of the target Sourcegraph instance"
@@ -160,10 +154,4 @@ variable "docker_registry_mirror_node_exporter_url" {
   type        = string
   default     = ""
   description = "A URL to a docker registry mirror node exporter to scrape (optional)"
-}
-
-variable "assign_public_ip" {
-  type        = bool
-  default     = true
-  description = "If false, no public IP will be associated with the executors. They cannot be scraped for metrics over the internet if this flag is false."
 }

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -1,3 +1,7 @@
+locals {
+  ip_cidr = "10.0.1.0/24"
+}
+
 resource "google_compute_network" "default" {
   name                    = "sourcegraph-executors"
   auto_create_subnetworks = false
@@ -8,6 +12,6 @@ resource "google_compute_subnetwork" "default" {
   name = "sourcegraph-executors-subnet"
 
   network       = google_compute_network.default.id
-  ip_cidr_range = "10.0.1.0/24"
+  ip_cidr_range = local.ip_cidr
   region        = var.region
 }

--- a/modules/networking/outputs.tf
+++ b/modules/networking/outputs.tf
@@ -5,3 +5,7 @@ output "network_id" {
 output "subnet_id" {
   value = google_compute_subnetwork.default.id
 }
+
+output "ip_cidr" {
+  value = local.ip_cidr
+}

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,12 @@ variable "docker_mirror_boot_disk_size" {
   description = "Docker registry mirror node disk size in GB"
 }
 
+variable "docker_mirror_http_access_cidr_ranges" {
+  type        = list(string)
+  default     = ["10.0.0.0/16"]
+  description = "DEPRECATED. This is not used anymore."
+}
+
 variable "executor_resource_prefix" {
   type        = string
   default     = ""
@@ -59,6 +65,12 @@ variable "executor_preemptible_machines" {
 variable "executor_instance_tag" {
   type        = string
   description = "A label tag to add to all the executors; can be used for filtering out the right instances in stackdriver monitoring"
+}
+
+variable "executor_http_access_cidr_ranges" {
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+  description = "DEPRECATED. This is not used anymore."
 }
 
 variable "executor_sourcegraph_external_url" {

--- a/variables.tf
+++ b/variables.tf
@@ -26,12 +26,6 @@ variable "docker_mirror_boot_disk_size" {
   description = "Docker registry mirror node disk size in GB"
 }
 
-variable "docker_mirror_http_access_cidr_ranges" {
-  type        = list(string)
-  default     = ["10.0.0.0/16"]
-  description = "CIDR range from where HTTP access to the Docker registry is acceptable."
-}
-
 variable "executor_resource_prefix" {
   type        = string
   default     = ""
@@ -65,12 +59,6 @@ variable "executor_preemptible_machines" {
 variable "executor_instance_tag" {
   type        = string
   description = "A label tag to add to all the executors; can be used for filtering out the right instances in stackdriver monitoring"
-}
-
-variable "executor_http_access_cidr_ranges" {
-  type        = list(string)
-  default     = ["0.0.0.0/0"]
-  description = "CIDR range from where HTTP access to the executor instances are acceptable."
 }
 
 variable "executor_sourcegraph_external_url" {


### PR DESCRIPTION
Removes the instance_scraper credentials stuff and the exposed HTTP port for the executor and registry.

### Test plan

Validate in k8s cluster.