### PR TITLE
Bump executor image to version that includes iptables config

### DIFF
--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -19,7 +19,7 @@ variable "resource_prefix" {
 
 variable "machine_image" {
   type        = string
-  default     = "projects/sourcegraph-ci/global/images/executor-d13dda0b80-161757"
+  default     = "projects/sourcegraph-ci/global/images/executor-7b98097c68-165686"
   description = "Executor node machine disk image to use for creating the boot volume"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -40,7 +40,7 @@ variable "executor_resource_prefix" {
 
 variable "executor_machine_image" {
   type        = string
-  default     = "projects/sourcegraph-ci/global/images/executor-d13dda0b80-161757"
+  default     = "projects/sourcegraph-ci/global/images/executor-7b98097c68-165686"
   description = "Executor node machine disk image to use for creating the boot volume"
 }
 


### PR DESCRIPTION
### Test plan

Verified this image before on k8s. 