### PR TITLE
Use native registry support of VM image

### DIFF
--- a/modules/executors/startup-script.sh.tpl
+++ b/modules/executors/startup-script.sh.tpl
@@ -7,19 +7,14 @@ ${key}="${value}"
 %{ endfor ~}
 
 # Conditionally set below
-STARTUP_SCRIPT_LINE=''
 DOCKER_REGISTRY_NODE_EXPORTER_URL_LINE=''
 
-# If a docker registry mirror is configured, create a startup script
-# that will configure docker to use the mirror. This requires writing
-# a docker configuration file and restarting the service.
+# If a docker registry mirror is configured, write the address in a magic file
+# that picks the address up at VM boot time and add it to the default set of
+# files to copy into the VMs.
 if [ "$${EXECUTOR_DOCKER_REGISTRY_MIRROR}" != '' ]; then
-  cat <<EOF >/vm-startup.sh
-set +ex
-mkdir -p /etc/docker
-echo "{\"registry-mirrors\": [\"$${EXECUTOR_DOCKER_REGISTRY_MIRROR}\"]}" > /etc/docker/daemon.json
-systemctl restart --now docker
-EOF
+  echo "$${EXECUTOR_DOCKER_REGISTRY_MIRROR}" >/docker-registry.txt
+  yq -i '.spec.vmDefaults.copyFiles[0].hostPath = "/docker-registry.txt" | .spec.vmDefaults.copyFiles[0].vmPath = "/docker-registry.txt"' /etc/ignite/config.yaml
 
   # Allow access to the docker registry from the VM.
   IP=$(echo $${EXECUTOR_DOCKER_REGISTRY_MIRROR} | grep -oE '//(.*?):' | sed 's/[\/:]//g')
@@ -29,9 +24,6 @@ EOF
 
   # Store the iptables config.
   iptables-save >/etc/iptables/rules.v4
-
-  chmod +x /vm-startup.sh
-  STARTUP_SCRIPT_LINE='EXECUTOR_VM_STARTUP_SCRIPT_PATH=/vm-startup.sh'
 
   if [ "$${DOCKER_REGISTRY_NODE_EXPORTER_URL}" != '' ]; then
     DOCKER_REGISTRY_NODE_EXPORTER_URL_LINE="DOCKER_REGISTRY_NODE_EXPORTER_URL=$${DOCKER_REGISTRY_NODE_EXPORTER_URL}"
@@ -51,7 +43,6 @@ EXECUTOR_FRONTEND_PASSWORD="$${SOURCEGRAPH_EXECUTOR_PROXY_PASSWORD}"
 EXECUTOR_NUM_TOTAL_JOBS="$${EXECUTOR_NUM_TOTAL_JOBS}"
 EXECUTOR_MAX_ACTIVE_TIME="$${EXECUTOR_MAX_ACTIVE_TIME}"
 EXECUTOR_USE_FIRECRACKER="$${EXECUTOR_USE_FIRECRACKER}"
-$${STARTUP_SCRIPT_LINE}
 $${DOCKER_REGISTRY_NODE_EXPORTER_URL_LINE}
 EOF
 

--- a/modules/executors/startup-script.sh.tpl
+++ b/modules/executors/startup-script.sh.tpl
@@ -14,7 +14,7 @@ DOCKER_REGISTRY_NODE_EXPORTER_URL_LINE=''
 # files to copy into the VMs.
 if [ "$${EXECUTOR_DOCKER_REGISTRY_MIRROR}" != '' ]; then
   echo "$${EXECUTOR_DOCKER_REGISTRY_MIRROR}" >/docker-registry.txt
-  yq -i '.spec.vmDefaults.copyFiles[0].hostPath = "/docker-registry.txt" | .spec.vmDefaults.copyFiles[0].vmPath = "/docker-registry.txt"' /etc/ignite/config.yaml
+  yq e -i '.spec.vmDefaults.copyFiles[0].hostPath = "/docker-registry.txt" | .spec.vmDefaults.copyFiles[0].vmPath = "/docker-registry.txt"' /etc/ignite/config.yaml
 
   # Allow access to the docker registry from the VM.
   IP=$(echo $${EXECUTOR_DOCKER_REGISTRY_MIRROR} | grep -oE '//(.*?):' | sed 's/[\/:]//g')


### PR DESCRIPTION
This'll make sure that we configure the daemon _before_ it starts so we don't have to restart it. Will be a little faster.

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
