### PR TITLE
Allow up to latest Terraform version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [single-executor example](https://github.com/sourcegraph/terraform-google-ex
 
 - [Terraform](https://www.terraform.io/) 
   - 4.1.x and below: `~> 1.1.x`
-  - 4.2.x and above: `<= 1.3.x`
+  - 4.2.x and above: `>= 1.1.0, < 2.0.0`
 - [hashicorp/google](https://registry.terraform.io/providers/hashicorp/google) 
   - `>= 3.26, < 5.0`
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [single-executor example](https://github.com/sourcegraph/terraform-google-ex
 
 - [Terraform](https://www.terraform.io/) 
   - 4.1.x and below: `~> 1.1.x`
-  - 4.2.x and above: `<= 1.4.0`
+  - 4.2.x and above: `<= 1.3.x`
 - [hashicorp/google](https://registry.terraform.io/providers/hashicorp/google) 
   - `>= 3.26, < 5.0`
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,13 @@ This repository provides a [Terraform module](https://learn.hashicorp.com/tutori
 This repository provides four submodules:
 
 1. The [executors module](https://registry.terraform.io/modules/sourcegraph/executors/google/4.1.0/submodules/executors) provisions compute resources for executors.
-1. The [docker-mirror module](https://registry.terraform.io/modules/sourcegraph/executors/google/4.1.0/submodules/docker-mirror) provisions a Docker registry pull-through cache.
-1. The [networking module](https://registry.terraform.io/modules/sourcegraph/executors/google/4.1.0/submodules/networking) provisions a network to be shared by the executor and Docker registry resources.
-1. The [credentials module](https://registry.terraform.io/modules/sourcegraph/executors/google/4.1.0/submodules/credentials) provisions credentials required by the Sourcegraph instance to enable observability and auto-scaling of executors.
+2. The [docker-mirror module](https://registry.terraform.io/modules/sourcegraph/executors/google/4.1.0/submodules/docker-mirror) provisions a Docker registry pull-through cache.
+3. The [networking module](https://registry.terraform.io/modules/sourcegraph/executors/google/4.1.0/submodules/networking) provisions a network to be shared by the executor and Docker registry resources.
+4. The [credentials module](https://registry.terraform.io/modules/sourcegraph/executors/google/4.1.0/submodules/credentials) provisions credentials required by the Sourcegraph instance to enable observability and auto-scaling of executors.
 
 The [multiple-executors example](https://github.com/sourcegraph/terraform-google-executors/blob/v4.1.0/examples/multiple-executors) uses the submodule directly to provision multiple executor resource groups performing different types of work. Follow this example if you are:
-
 1. Provisioning executors for use with multiple features (e.g., both [auto-indexing](https://docs.sourcegraph.com/code_intelligence/explanations/auto_indexing) and [server-side batch changes](https://docs.sourcegraph.com/batch_changes/explanations/server_side)), or
-1. Provisioning resources for multiple Sourcegraph instances (e.g., test, prod)
+2. Provisioning resources for multiple Sourcegraph instances (e.g., test, prod)
 
 This repository also provides a [root module](https://registry.terraform.io/modules/sourcegraph/executors/google/4.1.0) combining the executors, network, and docker-mirror resources into an easier to use package.
 
@@ -22,8 +21,11 @@ The [single-executor example](https://github.com/sourcegraph/terraform-google-ex
 
 ## Requirements
 
-- [Terraform](https://www.terraform.io/) ~> 1.1.0
-- [hashicorp/google](https://registry.terraform.io/providers/hashicorp/google) `>= 3.26, < 5.0`
+- [Terraform](https://www.terraform.io/) 
+  - 4.1.x and below: `~> 1.1.x`
+  - 4.2.x and above: `<= 1.4.0`
+- [hashicorp/google](https://registry.terraform.io/providers/hashicorp/google) 
+  - `>= 3.26, < 5.0`
 
 ## Setup
 
@@ -36,7 +38,7 @@ The **major** and **minor** versions both need to match the Sourcegraph version 
 For example:
 
 | **Sourcegraph version** | **Terraform module version** |
-| ----------------------- | ---------------------------- |
+|-------------------------|------------------------------|
 | 3.37.0                  | 3.37.\*                      |
 | 3.37.3                  | 3.37.\*                      |
 | 3.38.0                  | 3.38.\*                      |

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = "<= 1.4"
   required_providers {
     google = ">= 3.26, < 5.0"
   }

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "<= 1.4"
+  required_version = ">= 1.1.0, < 2.0.0"
   required_providers {
     google = ">= 3.26, < 5.0"
   }


### PR DESCRIPTION
Allows users to use the latest terraform version.

### Test plan

Manually deployed executors to GCP using Terraform `1.3.4`.
