### PR TITLE
Make random IDs suffix instead of prefix

### DIFF
--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -6,7 +6,7 @@ locals {
 
   resource_values = {
     compute_disk = {
-      name   = var.randomize_resource_names ? "docker-mirror-${random_id.compute_disk_registry_data[0].hex}" : "docker-registry-data"
+      name   = var.randomize_resource_names ? "${}docker-mirror-${random_id.compute_disk_registry_data[0].hex}" : "docker-registry-data"
       labels = var.randomize_resource_names ? var.labels : null
     }
     compute_instance = {
@@ -32,7 +32,6 @@ data "google_project" "project" {}
 
 resource "random_id" "compute_disk_registry_data" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 6
 }
 resource "google_compute_disk" "registry-data" {
@@ -51,7 +50,6 @@ data "google_compute_image" "mirror_image" {
 
 resource "random_id" "compute_instance_default" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 6
 }
 resource "google_compute_instance" "default" {
@@ -102,12 +100,10 @@ resource "google_compute_instance" "default" {
 
 resource "random_id" "compute_instance_network_tag" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 4
 }
 resource "random_id" "firewall_rule_prefix" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 4
 }
 
@@ -151,7 +147,6 @@ resource "google_compute_firewall" "ssh" {
 
 resource "random_id" "compute_address_static" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 6
 }
 
@@ -163,7 +158,6 @@ resource "google_compute_address" "static" {
 
 resource "random_id" "service_account" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 4
 }
 resource "google_service_account" "sa" {

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -1,28 +1,28 @@
 locals {
   network_tags = var.randomize_resource_names ? [
-    substr("docker-mirror-${random_id.compute_instance_network_tag[0].hex}", 0, 64),
+    substr("${var.resource_prefix}-docker-mirror-${random_id.compute_instance_network_tag[0].hex}", 0, 64),
     "docker-mirror"
   ] : []
 
   resource_values = {
     compute_disk = {
-      name   = var.randomize_resource_names ? "${}docker-mirror-${random_id.compute_disk_registry_data[0].hex}" : "docker-registry-data"
+      name   = var.randomize_resource_names ? "${var.resource_prefix}-docker-mirror-${random_id.compute_disk_registry_data[0].hex}" : "docker-registry-data"
       labels = var.randomize_resource_names ? var.labels : null
     }
     compute_instance = {
-      name   = var.randomize_resource_names ? "docker-mirror-${random_id.compute_instance_default[0].hex}" : "sourcegraph-executors-docker-registry-mirror"
+      name   = var.randomize_resource_names ? "${var.resource_prefix}-docker-mirror-${random_id.compute_instance_default[0].hex}" : "sourcegraph-executors-docker-registry-mirror"
       tags   = var.randomize_resource_names ? local.network_tags : ["docker-registry-mirror"]
       labels = var.randomize_resource_names ? merge({ executor_tag = "${var.instance_tag_prefix}-docker-mirror" }, var.labels) : { executor_tag = "${var.instance_tag_prefix}-docker-mirror" }
     }
     compute_firewall = {
-      name_prefix = var.randomize_resource_names ? "docker-mirror-${random_id.firewall_rule_prefix[0].hex}-" : "sourcegraph-executor-docker-mirror-"
+      name_prefix = var.randomize_resource_names ? "${var.resource_prefix}-docker-mirror-${random_id.firewall_rule_prefix[0].hex}-" : "sourcegraph-executor-docker-mirror-"
       target_tags = var.randomize_resource_names ? local.network_tags : ["docker-registry-mirror"]
     }
     compute_address = {
-      name = var.randomize_resource_names ? "docker-registry-mirror-${random_id.compute_address_static[0].hex}" : "sg-executor-docker-registry-mirror"
+      name = var.randomize_resource_names ? "${var.resource_prefix}-docker-registry-mirror-${random_id.compute_address_static[0].hex}" : "sg-executor-docker-registry-mirror"
     }
     service_account = {
-      account_id = var.randomize_resource_names ? substr("docker-mirror-${random_id.service_account[0].hex}", 0, 30) : "sg-executor-docker-registry"
+      account_id = var.randomize_resource_names ? substr("${var.resource_prefix}-docker-mirror-${random_id.service_account[0].hex}", 0, 30) : "sg-executor-docker-registry"
     }
   }
 }

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -1,28 +1,28 @@
 locals {
   network_tags = var.randomize_resource_names ? [
-    substr("${random_id.compute_instance_network_tag[0].hex}-docker-mirror", 0, 64),
+    substr("docker-mirror-${random_id.compute_instance_network_tag[0].hex}", 0, 64),
     "docker-mirror"
   ] : []
 
   resource_values = {
     compute_disk = {
-      name   = var.randomize_resource_names ? "${random_id.compute_disk_registry_data[0].hex}-docker-mirror" : "docker-registry-data"
+      name   = var.randomize_resource_names ? "docker-mirror-${random_id.compute_disk_registry_data[0].hex}" : "docker-registry-data"
       labels = var.randomize_resource_names ? var.labels : null
     }
     compute_instance = {
-      name   = var.randomize_resource_names ? "${random_id.compute_instance_default[0].hex}-docker-mirror" : "sourcegraph-executors-docker-registry-mirror"
+      name   = var.randomize_resource_names ? "docker-mirror-${random_id.compute_instance_default[0].hex}" : "sourcegraph-executors-docker-registry-mirror"
       tags   = var.randomize_resource_names ? local.network_tags : ["docker-registry-mirror"]
       labels = var.randomize_resource_names ? merge({ executor_tag = "${var.instance_tag_prefix}-docker-mirror" }, var.labels) : { executor_tag = "${var.instance_tag_prefix}-docker-mirror" }
     }
     compute_firewall = {
-      name_prefix = var.randomize_resource_names ? "${random_id.firewall_rule_prefix[0].hex}-docker-mirror-" : "sourcegraph-executor-docker-mirror-"
+      name_prefix = var.randomize_resource_names ? "docker-mirror-${random_id.firewall_rule_prefix[0].hex}-" : "sourcegraph-executor-docker-mirror-"
       target_tags = var.randomize_resource_names ? local.network_tags : ["docker-registry-mirror"]
     }
     compute_address = {
-      name = var.randomize_resource_names ? "${random_id.compute_address_static[0].hex}-docker-registry-mirror" : "sg-executor-docker-registry-mirror"
+      name = var.randomize_resource_names ? "docker-registry-mirror-${random_id.compute_address_static[0].hex}" : "sg-executor-docker-registry-mirror"
     }
     service_account = {
-      account_id = var.randomize_resource_names ? substr("${random_id.service_account[0].hex}-docker-mirror", 0, 30) : "sg-executor-docker-registry"
+      account_id = var.randomize_resource_names ? substr("docker-mirror-${random_id.service_account[0].hex}", 0, 30) : "sg-executor-docker-registry"
     }
   }
 }

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -65,8 +65,8 @@ variable "resource_prefix" {
   description = "A string to prefix all resources with"
   default     = ""
   validation {
-    condition     = var.resource_prefix == "" || can(regex("^[a-z].*", var.resource_prefix))
-    error_message = "The variable executor_resource_prefix must start with a lowercase letter."
+    condition     = var.resource_prefix == "" || (can(regex("^[a-z].*", var.resource_prefix)) && endswith(var.resource_prefix, "-"))
+    error_message = "The variable resource_prefix must start with a lowercase letter and end with a '-'."
   }
 }
 

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -64,6 +64,10 @@ variable "resource_prefix" {
   type        = string
   description = "A string to prefix all resources with"
   default     = ""
+  validation {
+    condition     = var.resource_prefix == "" || can(regex("^[a-z].*", var.resource_prefix))
+    error_message = "The variable executor_resource_prefix must start with a lowercase letter."
+  }
 }
 
 variable "labels" {
@@ -73,6 +77,7 @@ variable "labels" {
 }
 
 variable "randomize_resource_names" {
+  default     = false
   type        = bool
   description = "Use randomized names for resources. Disable if you are upgrading existing executors that were deployed using the legacy naming conventions, unless you want to recreate executor resources on GCP."
 }

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -65,8 +65,8 @@ variable "resource_prefix" {
   description = "A string to prefix all resources with"
   default     = ""
   validation {
-    condition     = var.resource_prefix == "" || (can(regex("^[a-z].*", var.resource_prefix)) && endswith(var.resource_prefix, "-"))
-    error_message = "The variable resource_prefix must start with a lowercase letter and end with a '-'."
+    condition     = var.resource_prefix == "" || can(regex("^[a-z].*", var.resource_prefix))
+    error_message = "The variable resource_prefix must start with a lowercase letter."
   }
 }
 

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -2,14 +2,14 @@ locals {
   prefix = var.resource_prefix != "" ? "${var.resource_prefix}-sourcegraph-" : "sourcegraph-"
 
   network_tags = var.randomize_resource_names ? [
-    substr("${random_id.compute_instance_network_tag[0].hex}-executors", 0, 64),
+    substr("executors-${random_id.compute_instance_network_tag[0].hex}", 0, 64),
     var.instance_tag,
     "executors"
   ] : []
 
   resource_values = {
     service_account = {
-      account_id   = var.randomize_resource_names ? substr("${random_id.service_account[0].hex}-executors", 0, 30) : "${substr(local.prefix, 0, 19)}executors"
+      account_id   = var.randomize_resource_names ? substr("executors-${random_id.service_account[0].hex}", 0, 30) : "${substr(local.prefix, 0, 19)}executors"
       display_name = var.randomize_resource_names ? "Service account for Sourcegraph executors" : "${var.resource_prefix}${var.resource_prefix != "" ? " " : ""}sourcegraph executors"
     }
     compute_instance_template = {
@@ -18,14 +18,14 @@ locals {
       labels      = var.randomize_resource_names ? merge({ executor_tag = var.instance_tag }, var.labels) : { executor_tag = var.instance_tag }
     }
     compute_instance_group_manager = {
-      name               = var.randomize_resource_names ? "${random_id.compute_instance_group_executor[0].hex}-executors" : "${local.prefix}executor"
-      base_instance_name = var.randomize_resource_names ? "${random_id.compute_instance_group_executor[0].hex}-executors" : "${local.prefix}executor"
+      name               = var.randomize_resource_names ? "executors-${random_id.compute_instance_group_executor[0].hex}" : "${local.prefix}executor"
+      base_instance_name = var.randomize_resource_names ? "executors-${random_id.compute_instance_group_executor[0].hex}" : "${local.prefix}executor"
     }
     compute_autoscaler = {
-      name = var.randomize_resource_names ? "${random_id.compute_instance_group_executor[0].hex}-executors-autoscaler" : "${local.prefix}executor-autoscaler"
+      name = var.randomize_resource_names ? "executors-autoscaler-${random_id.compute_instance_group_executor[0].hex}" : "${local.prefix}executor-autoscaler"
     }
     compute_firewall = {
-      name        = var.randomize_resource_names ? "${random_id.firewall_rule_prefix[0].hex}-executors-ssh" : "${local.prefix}executor-ssh-firewall"
+      name        = var.randomize_resource_names ? "executors-ssh-${random_id.firewall_rule_prefix[0].hex}" : "${local.prefix}executor-ssh-firewall"
       target_tags = var.randomize_resource_names ? local.network_tags : ["${local.prefix}executor"]
     }
   }

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -2,30 +2,30 @@ locals {
   prefix = var.resource_prefix != "" ? "${var.resource_prefix}-sourcegraph-" : "sourcegraph-"
 
   network_tags = var.randomize_resource_names ? [
-    substr("executors-${random_id.compute_instance_network_tag[0].hex}", 0, 64),
+    substr("${var.resource_prefix}-executors-${random_id.compute_instance_network_tag[0].hex}", 0, 64),
     var.instance_tag,
     "executors"
   ] : []
 
   resource_values = {
     service_account = {
-      account_id   = var.randomize_resource_names ? substr("executors-${random_id.service_account[0].hex}", 0, 30) : "${substr(local.prefix, 0, 19)}executors"
+      account_id   = var.randomize_resource_names ? substr("${var.resource_prefix}-executors-${random_id.service_account[0].hex}", 0, 30) : "${substr(local.prefix, 0, 19)}executors"
       display_name = var.randomize_resource_names ? "Service account for Sourcegraph executors" : "${var.resource_prefix}${var.resource_prefix != "" ? " " : ""}sourcegraph executors"
     }
     compute_instance_template = {
-      name_prefix = var.randomize_resource_names ? "${substr(var.resource_prefix, 0, 28)}executors-" : "${substr(local.prefix, 0, 28)}executor-"
+      name_prefix = var.randomize_resource_names ? "${substr(var.resource_prefix, 0, 28)}-executors-" : "${substr(local.prefix, 0, 28)}executor-"
       tags        = var.randomize_resource_names ? local.network_tags : ["${local.prefix}executor"]
       labels      = var.randomize_resource_names ? merge({ executor_tag = var.instance_tag }, var.labels) : { executor_tag = var.instance_tag }
     }
     compute_instance_group_manager = {
-      name               = var.randomize_resource_names ? "executors-${random_id.compute_instance_group_executor[0].hex}" : "${local.prefix}executor"
-      base_instance_name = var.randomize_resource_names ? "executors-${random_id.compute_instance_group_executor[0].hex}" : "${local.prefix}executor"
+      name               = var.randomize_resource_names ? "${var.resource_prefix}-executors-${random_id.compute_instance_group_executor[0].hex}" : "${local.prefix}executor"
+      base_instance_name = var.randomize_resource_names ? "${var.resource_prefix}-executors-${random_id.compute_instance_group_executor[0].hex}" : "${local.prefix}executor"
     }
     compute_autoscaler = {
-      name = var.randomize_resource_names ? "executors-autoscaler-${random_id.compute_instance_group_executor[0].hex}" : "${local.prefix}executor-autoscaler"
+      name = var.randomize_resource_names ? "${var.resource_prefix}-executors-autoscaler-${random_id.compute_instance_group_executor[0].hex}" : "${local.prefix}executor-autoscaler"
     }
     compute_firewall = {
-      name        = var.randomize_resource_names ? "executors-ssh-${random_id.firewall_rule_prefix[0].hex}" : "${local.prefix}executor-ssh-firewall"
+      name        = var.randomize_resource_names ? "${var.resource_prefix}-executors-ssh-${random_id.firewall_rule_prefix[0].hex}" : "${local.prefix}executor-ssh-firewall"
       target_tags = var.randomize_resource_names ? local.network_tags : ["${local.prefix}executor"]
     }
   }
@@ -37,7 +37,6 @@ data "google_project" "project" {}
 
 resource "random_id" "service_account" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 4
 }
 resource "google_service_account" "sa" {
@@ -65,7 +64,6 @@ data "google_compute_image" "executor_image" {
 
 resource "random_id" "compute_instance_network_tag" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 4
 }
 resource "google_compute_instance_template" "executor-instance-template" {
@@ -138,7 +136,6 @@ resource "google_compute_instance_template" "executor-instance-template" {
 
 resource "random_id" "compute_instance_group_executor" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 4
 }
 resource "google_compute_instance_group_manager" "executor" {
@@ -190,7 +187,6 @@ resource "google_compute_autoscaler" "executor-autoscaler" {
 
 resource "random_id" "firewall_rule_prefix" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 4
 }
 resource "google_compute_firewall" "executor-ssh-access" {

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -17,6 +17,10 @@ variable "resource_prefix" {
   type        = string
   default     = ""
   description = "An optional prefix to add to all resources created."
+  validation {
+    condition     = var.resource_prefix == "" || can(regex("^[a-z].*", var.resource_prefix))
+    error_message = "The variable executor_resource_prefix must start with a lowercase letter."
+  }
 }
 
 variable "machine_image" {
@@ -185,6 +189,7 @@ variable "labels" {
 }
 
 variable "randomize_resource_names" {
+  default     = false
   type        = bool
   description = "Use randomized names for resources. Disable if you are upgrading existing executors that were deployed using the legacy naming conventions, unless you want to recreate executor resources on GCP."
 }

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -18,8 +18,8 @@ variable "resource_prefix" {
   default     = ""
   description = "An optional prefix to add to all resources created."
   validation {
-    condition     = var.resource_prefix == "" || can(regex("^[a-z].*", var.resource_prefix))
-    error_message = "The variable executor_resource_prefix must start with a lowercase letter."
+    condition     = var.resource_prefix == "" || (can(regex("^[a-z].*", var.resource_prefix)) && endswith(var.resource_prefix, "-"))
+    error_message = "The variable resource_prefix must start with a lowercase letter and end with a '-'."
   }
 }
 

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -18,8 +18,8 @@ variable "resource_prefix" {
   default     = ""
   description = "An optional prefix to add to all resources created."
   validation {
-    condition     = var.resource_prefix == "" || (can(regex("^[a-z].*", var.resource_prefix)) && endswith(var.resource_prefix, "-"))
-    error_message = "The variable resource_prefix must start with a lowercase letter and end with a '-'."
+    condition     = var.resource_prefix == "" || can(regex("^[a-z].*", var.resource_prefix))
+    error_message = "The variable resource_prefix must start with a lowercase letter."
   }
 }
 

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -3,19 +3,19 @@ locals {
 
   resource_values = {
     compute_network = {
-      name = var.randomize_resource_names ? "executors-${random_id.network[0].hex}" : "sourcegraph-executors"
+      name = var.randomize_resource_names ? "${var.resource_prefix}-executors-${random_id.network[0].hex}" : "sourcegraph-executors"
     }
     compute_subnetwork = {
-      name = var.randomize_resource_names ? "executors-subnet-${random_id.subnetwork[0].hex}" : "sourcegraph-executors-subnet"
+      name = var.randomize_resource_names ? "${var.resource_prefix}-executors-subnet-${random_id.subnetwork[0].hex}" : "sourcegraph-executors-subnet"
     }
     compute_router = {
-      name = var.randomize_resource_names ? "executors-${random_id.router[0].hex}" : "sourcegraph-executors-router"
+      name = var.randomize_resource_names ? "${var.resource_prefix}-executors-${random_id.router[0].hex}" : "sourcegraph-executors-router"
     }
     compute_address = {
-      name = var.randomize_resource_names ? "executors-${random_id.compute_address_nat[0].hex}" : "sourcegraph-executors-router"
+      name = var.randomize_resource_names ? "${var.resource_prefix}-executors-${random_id.compute_address_nat[0].hex}" : "sourcegraph-executors-router"
     }
     compute_router_nat = {
-      name = var.randomize_resource_names ? "executors-${random_id.router_nat[0].hex}" : "sourcegraph-executors-nat"
+      name = var.randomize_resource_names ? "${var.resource_prefix}-executors-${random_id.router_nat[0].hex}" : "sourcegraph-executors-nat"
     }
   }
 }
@@ -23,7 +23,6 @@ locals {
 
 resource "random_id" "network" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 6
 }
 resource "google_compute_network" "default" {
@@ -34,7 +33,6 @@ resource "google_compute_network" "default" {
 
 resource "random_id" "subnetwork" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 6
 }
 resource "google_compute_subnetwork" "default" {
@@ -48,7 +46,6 @@ resource "google_compute_subnetwork" "default" {
 # If NAT mode is enabled, we create a custom router for our network.
 resource "random_id" "router" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 6
 }
 resource "google_compute_router" "default" {
@@ -61,7 +58,6 @@ resource "google_compute_router" "default" {
 
 resource "random_id" "compute_address_nat" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 6
 }
 # Then NAT mode is enabled, we want a static IP for it.
@@ -74,7 +70,6 @@ resource "google_compute_address" "nat" {
 
 resource "random_id" "router_nat" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 6
 }
 resource "google_compute_router_nat" "default" {

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -3,19 +3,19 @@ locals {
 
   resource_values = {
     compute_network = {
-      name = var.randomize_resource_names ? "${random_id.network[0].hex}-executors" : "sourcegraph-executors"
+      name = var.randomize_resource_names ? "executors-${random_id.network[0].hex}" : "sourcegraph-executors"
     }
     compute_subnetwork = {
-      name = var.randomize_resource_names ? "${random_id.subnetwork[0].hex}-executors-subnet" : "sourcegraph-executors-subnet"
+      name = var.randomize_resource_names ? "executors-subnet-${random_id.subnetwork[0].hex}" : "sourcegraph-executors-subnet"
     }
     compute_router = {
-      name = var.randomize_resource_names ? "${random_id.router[0].hex}-executors" : "sourcegraph-executors-router"
+      name = var.randomize_resource_names ? "executors-${random_id.router[0].hex}" : "sourcegraph-executors-router"
     }
     compute_address = {
-      name = var.randomize_resource_names ? "${random_id.compute_address_nat[0].hex}-executors" : "sourcegraph-executors-router"
+      name = var.randomize_resource_names ? "executors-${random_id.compute_address_nat[0].hex}" : "sourcegraph-executors-router"
     }
     compute_router_nat = {
-      name = var.randomize_resource_names ? "${random_id.router_nat[0].hex}-executors" : "sourcegraph-executors-nat"
+      name = var.randomize_resource_names ? "executors-${random_id.router_nat[0].hex}" : "sourcegraph-executors-nat"
     }
   }
 }

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -20,8 +20,8 @@ variable "resource_prefix" {
   default     = ""
   description = "An optional prefix to add to all resources created."
   validation {
-    condition     = var.resource_prefix == "" || (can(regex("^[a-z].*", var.resource_prefix)) && endswith(var.resource_prefix, "-"))
-    error_message = "The variable resource_prefix must start with a lowercase letter and end with a '-'."
+    condition     = var.resource_prefix == "" || can(regex("^[a-z].*", var.resource_prefix))
+    error_message = "The variable resource_prefix must start with a lowercase letter."
   }
 }
 

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -19,9 +19,14 @@ variable "resource_prefix" {
   type        = string
   default     = ""
   description = "An optional prefix to add to all resources created."
+  validation {
+    condition     = var.resource_prefix == "" || can(regex("^[a-z].*", var.resource_prefix))
+    error_message = "The variable executor_resource_prefix must start with a lowercase letter."
+  }
 }
 
 variable "randomize_resource_names" {
+  default     = false
   type        = bool
   description = "Use randomized names for resources. Disable if you are upgrading existing executors that were deployed using the legacy naming conventions, unless you want to recreate executor resources on GCP."
 }

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -20,8 +20,8 @@ variable "resource_prefix" {
   default     = ""
   description = "An optional prefix to add to all resources created."
   validation {
-    condition     = var.resource_prefix == "" || can(regex("^[a-z].*", var.resource_prefix))
-    error_message = "The variable executor_resource_prefix must start with a lowercase letter."
+    condition     = var.resource_prefix == "" || (can(regex("^[a-z].*", var.resource_prefix)) && endswith(var.resource_prefix, "-"))
+    error_message = "The variable resource_prefix must start with a lowercase letter and end with a '-'."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -37,8 +37,8 @@ variable "executor_resource_prefix" {
   default     = ""
   description = "An optional prefix to add to all resources created."
   validation {
-    condition     = var.executor_resource_prefix == "" || (can(regex("^[a-z].*", var.executor_resource_prefix)) && endswith(var.executor_resource_prefix, "-"))
-    error_message = "The variable executor_resource_prefix must start with a lowercase letter and end with a '-'."
+    condition     = var.executor_resource_prefix == "" || can(regex("^[a-z].*", var.executor_resource_prefix))
+    error_message = "The variable executor_resource_prefix must start with a lowercase letter."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -37,8 +37,8 @@ variable "executor_resource_prefix" {
   default     = ""
   description = "An optional prefix to add to all resources created."
   validation {
-    condition     = var.executor_resource_prefix == "" || can(regex("^[a-z].*", var.executor_resource_prefix))
-    error_message = "The variable executor_resource_prefix must start with a lowercase letter."
+    condition     = var.executor_resource_prefix == "" || (can(regex("^[a-z].*", var.executor_resource_prefix)) && endswith(var.executor_resource_prefix, "-"))
+    error_message = "The variable executor_resource_prefix must start with a lowercase letter and end with a '-'."
   }
 }
 


### PR DESCRIPTION
Google has naming requirements that say "must start with a-z", which is not necessarily the case for the hex ids. This felt like the easiest fix to me.

### Test plan

Rolled out to dogfood.