### PR TITLE
Allow to use a local SSD for executors firecracker data dir

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,7 @@ module "gcp-docker-mirror" {
   boot_disk_size           = var.docker_mirror_boot_disk_size
   instance_tag_prefix      = var.executor_instance_tag
   assign_public_ip         = var.private_networking ? false : true
+  use_local_ssd            = var.docker_mirror_use_local_ssd
 }
 
 module "gcp-executors" {
@@ -61,4 +62,5 @@ module "gcp-executors" {
   docker_registry_mirror_node_exporter_url = "http://${module.gcp-docker-mirror.ip_address}:9999"
   assign_public_ip                         = var.private_networking ? false : true
   docker_auth_config                       = var.executor_docker_auth_config
+  use_local_ssd                            = var.executor_use_local_ssd
 }

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -61,6 +61,8 @@ resource "google_compute_instance" "default" {
   zone         = var.zone
   tags         = local.resource_values.compute_instance.tags
 
+  allow_stopping_for_update = true
+
   labels = local.resource_values.compute_instance.labels
 
   service_account {

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -75,10 +75,9 @@ resource "google_compute_instance" "default" {
 
   boot_disk {
     initialize_params {
-      image  = var.machine_image != "" ? var.machine_image : data.google_compute_image.mirror_image.0.self_link
-      size   = var.boot_disk_size
-      type   = "pd-ssd"
-      labels = local.resource_values.compute_instance.labels
+      image = var.machine_image != "" ? var.machine_image : data.google_compute_image.mirror_image.0.self_link
+      size  = var.boot_disk_size
+      type  = "pd-ssd"
     }
   }
 

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -36,7 +36,7 @@ resource "random_id" "compute_disk_registry_data" {
   byte_length = 6
 }
 resource "google_compute_disk" "registry-data" {
-  count = var.use_local_ssd ? 0 : 1
+  count  = var.use_local_ssd ? 0 : 1
   name   = local.resource_values.compute_disk.name
   type   = "pd-ssd"
   zone   = var.zone
@@ -75,9 +75,9 @@ resource "google_compute_instance" "default" {
 
   boot_disk {
     initialize_params {
-      image = var.machine_image != "" ? var.machine_image : data.google_compute_image.mirror_image.0.self_link
-      size  = var.boot_disk_size
-      type  = "pd-ssd"
+      image  = var.machine_image != "" ? var.machine_image : data.google_compute_image.mirror_image.0.self_link
+      size   = var.boot_disk_size
+      type   = "pd-ssd"
       labels = local.resource_values.compute_instance.labels
     }
   }

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -7,7 +7,7 @@ locals {
   resource_values = {
     compute_disk = {
       name   = var.randomize_resource_names ? "docker-mirror-${random_id.compute_disk_registry_data[0].hex}" : "docker-registry-data"
-      labels = var.randomize_resource_names ? var.labels : null
+      labels = var.randomize_resource_names ? merge({ executor_tag = "${var.instance_tag_prefix}-docker-mirror" }, var.labels) : { executor_tag = "${var.instance_tag_prefix}-docker-mirror" }
     }
     compute_instance = {
       name   = var.randomize_resource_names ? "docker-mirror-${random_id.compute_instance_default[0].hex}" : "sourcegraph-executors-docker-registry-mirror"
@@ -78,6 +78,7 @@ resource "google_compute_instance" "default" {
       image = var.machine_image != "" ? var.machine_image : data.google_compute_image.mirror_image.0.self_link
       size  = var.boot_disk_size
       type  = "pd-ssd"
+      labels = local.resource_values.compute_instance.labels
     }
   }
 

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -7,7 +7,7 @@ locals {
   resource_values = {
     compute_disk = {
       name   = var.randomize_resource_names ? "${var.resource_prefix}-docker-mirror-${random_id.compute_disk_registry_data[0].hex}" : "docker-registry-data"
-      labels = var.randomize_resource_names ? merge({ executor_tag = "${var.instance_tag_prefix}-docker-mirror" }, var.labels) : { executor_tag = "${var.instance_tag_prefix}-docker-mirror" }
+      labels = var.randomize_resource_names ? var.labels : null
     }
     compute_instance = {
       name   = var.randomize_resource_names ? "${var.resource_prefix}-docker-mirror-${random_id.compute_instance_default[0].hex}" : "sourcegraph-executors-docker-registry-mirror"

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -1,6 +1,6 @@
 locals {
   network_tags = var.randomize_resource_names ? [
-    substr("docker-mirror-${random_id.compute_instance_network_tag[0].hex}", 0, 64),
+    substr("${random_id.compute_instance_network_tag[0].hex}-docker-mirror", 0, 64),
     "docker-mirror"
   ] : []
 
@@ -10,19 +10,19 @@ locals {
       labels = var.randomize_resource_names ? merge({ executor_tag = "${var.instance_tag_prefix}-docker-mirror" }, var.labels) : { executor_tag = "${var.instance_tag_prefix}-docker-mirror" }
     }
     compute_instance = {
-      name   = var.randomize_resource_names ? "docker-mirror-${random_id.compute_instance_default[0].hex}" : "sourcegraph-executors-docker-registry-mirror"
+      name   = var.randomize_resource_names ? "${random_id.compute_instance_default[0].hex}-docker-mirror" : "sourcegraph-executors-docker-registry-mirror"
       tags   = var.randomize_resource_names ? local.network_tags : ["docker-registry-mirror"]
       labels = var.randomize_resource_names ? merge({ executor_tag = "${var.instance_tag_prefix}-docker-mirror" }, var.labels) : { executor_tag = "${var.instance_tag_prefix}-docker-mirror" }
     }
     compute_firewall = {
-      name_prefix = var.randomize_resource_names ? "docker-mirror-${random_id.firewall_rule_prefix[0].hex}-" : "sourcegraph-executor-docker-mirror-"
+      name_prefix = var.randomize_resource_names ? "${random_id.firewall_rule_prefix[0].hex}-docker-mirror-" : "sourcegraph-executor-docker-mirror-"
       target_tags = var.randomize_resource_names ? local.network_tags : ["docker-registry-mirror"]
     }
     compute_address = {
-      name = var.randomize_resource_names ? "docker-registry-mirror-${random_id.compute_address_static[0].hex}" : "sg-executor-docker-registry-mirror"
+      name = var.randomize_resource_names ? "${random_id.compute_address_static[0].hex}-docker-registry-mirror" : "sg-executor-docker-registry-mirror"
     }
     service_account = {
-      account_id = var.randomize_resource_names ? substr("docker-mirror-${random_id.service_account[0].hex}", 0, 30) : "sg-executor-docker-registry"
+      account_id = var.randomize_resource_names ? substr("${random_id.service_account[0].hex}-docker-mirror", 0, 30) : "sg-executor-docker-registry"
     }
   }
 }

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -1,28 +1,28 @@
 locals {
   network_tags = var.randomize_resource_names ? [
-    substr("${random_id.compute_instance_network_tag[0].hex}-docker-mirror", 0, 64),
+    substr("docker-mirror-${random_id.compute_instance_network_tag[0].hex}", 0, 64),
     "docker-mirror"
   ] : []
 
   resource_values = {
     compute_disk = {
-      name   = var.randomize_resource_names ? "${random_id.compute_disk_registry_data[0].hex}-docker-mirror" : "docker-registry-data"
+      name   = var.randomize_resource_names ? "docker-mirror-${random_id.compute_disk_registry_data[0].hex}" : "docker-registry-data"
       labels = var.randomize_resource_names ? var.labels : null
     }
     compute_instance = {
-      name   = var.randomize_resource_names ? "${random_id.compute_instance_default[0].hex}-docker-mirror" : "sourcegraph-executors-docker-registry-mirror"
+      name   = var.randomize_resource_names ? "docker-mirror-${random_id.compute_instance_default[0].hex}" : "sourcegraph-executors-docker-registry-mirror"
       tags   = var.randomize_resource_names ? local.network_tags : ["docker-registry-mirror"]
       labels = var.randomize_resource_names ? merge({ executor_tag = "${var.instance_tag_prefix}-docker-mirror" }, var.labels) : { executor_tag = "${var.instance_tag_prefix}-docker-mirror" }
     }
     compute_firewall = {
-      name_prefix = var.randomize_resource_names ? "${random_id.firewall_rule_prefix[0].hex}-docker-mirror-" : "sourcegraph-executor-docker-mirror-"
+      name_prefix = var.randomize_resource_names ? "docker-mirror-${random_id.firewall_rule_prefix[0].hex}-" : "sourcegraph-executor-docker-mirror-"
       target_tags = var.randomize_resource_names ? local.network_tags : ["docker-registry-mirror"]
     }
     compute_address = {
-      name = var.randomize_resource_names ? "${random_id.compute_address_static[0].hex}-docker-registry-mirror" : "sg-executor-docker-registry-mirror"
+      name = var.randomize_resource_names ? "docker-registry-mirror-${random_id.compute_address_static[0].hex}" : "sg-executor-docker-registry-mirror"
     }
     service_account = {
-      account_id = var.randomize_resource_names ? substr("${random_id.service_account[0].hex}-docker-mirror", 0, 30) : "sg-executor-docker-registry"
+      account_id = var.randomize_resource_names ? substr("docker-mirror-${random_id.service_account[0].hex}", 0, 30) : "sg-executor-docker-registry"
     }
   }
 }

--- a/modules/docker-mirror/startup-script.sh.tpl
+++ b/modules/docker-mirror/startup-script.sh.tpl
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-ln -s /dev/disk/by-id/google-registry-data /dev/sdh
+## Pull terraform variables into the environment.
+%{ for key, value in environment_variables }
+${key}="${replace(value, "\"", "\\\\\\\"")}"
+%{ endfor ~}
+
+if [ "$${USE_LOCAL_SSD}" = "true" ]; then
+    ln -s /dev/disk/by-id/google-local-nvme-ssd-0 /dev/sdh
+else
+    ln -s /dev/disk/by-id/google-registry-data /dev/sdh
+fi
 
 REALPATH="$(realpath /dev/sdh)"
 # Ensure /dev/sdh has a file system.
 if [ "$(file -s "$REALPATH")" == "$REALPATH: data" ]; then
-  mkfs.ext4 /dev/sdh
+    mkfs.ext4 /dev/sdh
 fi
 
 # Mount /dev/sdh to /mnt/registry.

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -21,7 +21,7 @@ variable "machine_image" {
 
 variable "machine_type" {
   type        = string
-  default     = "n2-standard-2" // 2 vCPU, 8GB
+  default     = "n1-standard-2" // 2 vCPU, 7.5GB
   description = "Docker registry mirror node machine type."
 }
 

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -21,7 +21,7 @@ variable "machine_image" {
 
 variable "machine_type" {
   type        = string
-  default     = "n1-standard-2" // 2 vCPU, 7.5GB
+  default     = "n2-standard-2" // 2 vCPU, 8GB
   description = "Docker registry mirror node machine type."
 }
 

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -76,3 +76,9 @@ variable "randomize_resource_names" {
   type        = bool
   description = "Use randomized names for resources. Disable if you are upgrading existing executors that were deployed using the legacy naming conventions, unless you want to recreate executor resources on GCP."
 }
+
+variable "use_local_ssd" {
+  type        = bool
+  default     = false
+  description = "Use a local SSD for the data dir of the registry instead of a persistent disk. This will mean that the cache will reset after the instance is replaced! disk_size is also not honored when true."
+}

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -80,8 +80,6 @@ resource "google_compute_instance_template" "executor-instance-template" {
   # This is used for networking.
   tags = local.resource_values.compute_instance_template.tags
 
-  labels = local.resource_values.compute_instance_template.labels
-
   scheduling {
     automatic_restart = false
     preemptible       = var.preemptible_machines
@@ -218,7 +216,6 @@ resource "google_compute_firewall" "executor-ssh-access" {
   name        = local.resource_values.compute_firewall.name
   network     = var.network_id
   target_tags = local.resource_values.compute_firewall.target_tags
-  labels = local.resource_values.compute_instance_template.labels
 
   # Google IAP source range.
   source_ranges = ["35.235.240.0/20"]

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -30,6 +30,8 @@ locals {
     }
   }
 
+  # if using local SSDs and using the default value of 100, lower it to 20, otherwise use the configured value either way.
+  boot_disk_size = var.use_local_ssd ? var.boot_disk_size == 100 ? 20 : var.boot_disk_size : var.boot_disk_size
 }
 
 # Fetch the google project set in the currently used provider.
@@ -95,7 +97,7 @@ resource "google_compute_instance_template" "executor-instance-template" {
 
   disk {
     source_image = var.machine_image != "" ? var.machine_image : data.google_compute_image.executor_image.0.self_link
-    disk_size_gb = var.boot_disk_size
+    disk_size_gb = local.boot_disk_size
     boot         = true
     disk_type    = "pd-ssd"
   }

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -100,7 +100,6 @@ resource "google_compute_instance_template" "executor-instance-template" {
     disk_size_gb = local.boot_disk_size
     boot         = true
     disk_type    = "pd-ssd"
-    labels       = local.resource_values.compute_instance_template.labels
   }
 
   dynamic "disk" {
@@ -111,7 +110,6 @@ resource "google_compute_instance_template" "executor-instance-template" {
       disk_type    = "local-ssd"
       type         = "SCRATCH"
       disk_size_gb = 375
-      labels       = local.resource_values.compute_instance_template.labels
     }
   }
 

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -2,14 +2,14 @@ locals {
   prefix = var.resource_prefix != "" ? "${var.resource_prefix}-sourcegraph-" : "sourcegraph-"
 
   network_tags = var.randomize_resource_names ? [
-    substr("${random_id.compute_instance_network_tag[0].hex}-executors", 0, 64),
+    substr("executors-${random_id.compute_instance_network_tag[0].hex}", 0, 64),
     var.instance_tag,
     "executors"
   ] : []
 
   resource_values = {
     service_account = {
-      account_id   = var.randomize_resource_names ? substr("${random_id.service_account[0].hex}-executors", 0, 30) : "${substr(local.prefix, 0, 19)}executors"
+      account_id   = var.randomize_resource_names ? substr("executors-${random_id.service_account[0].hex}", 0, 30) : "${substr(local.prefix, 0, 19)}executors"
       display_name = var.randomize_resource_names ? "Service account for Sourcegraph executors" : "${var.resource_prefix}${var.resource_prefix != "" ? " " : ""}sourcegraph executors"
     }
     compute_instance_template = {
@@ -18,14 +18,14 @@ locals {
       labels      = var.randomize_resource_names ? merge({ executor_tag = var.instance_tag }, var.labels) : { executor_tag = var.instance_tag }
     }
     compute_instance_group_manager = {
-      name               = var.randomize_resource_names ? "${random_id.compute_instance_group_executor[0].hex}-executors" : "${local.prefix}executor"
-      base_instance_name = var.randomize_resource_names ? "${random_id.compute_instance_group_executor[0].hex}-executors" : "${local.prefix}executor"
+      name               = var.randomize_resource_names ? "executors-${random_id.compute_instance_group_executor[0].hex}" : "${local.prefix}executor"
+      base_instance_name = var.randomize_resource_names ? "executors-${random_id.compute_instance_group_executor[0].hex}" : "${local.prefix}executor"
     }
     compute_autoscaler = {
-      name = var.randomize_resource_names ? "${random_id.compute_instance_group_executor[0].hex}-executors-autoscaler" : "${local.prefix}executor-autoscaler"
+      name = var.randomize_resource_names ? "executors-autoscaler-${random_id.compute_instance_group_executor[0].hex}" : "${local.prefix}executor-autoscaler"
     }
     compute_firewall = {
-      name        = var.randomize_resource_names ? "${random_id.firewall_rule_prefix[0].hex}-executors-ssh" : "${local.prefix}executor-ssh-firewall"
+      name        = var.randomize_resource_names ? "executors-ssh-${random_id.firewall_rule_prefix[0].hex}" : "${local.prefix}executor-ssh-firewall"
       target_tags = var.randomize_resource_names ? local.network_tags : ["${local.prefix}executor"]
     }
   }

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -100,6 +100,17 @@ resource "google_compute_instance_template" "executor-instance-template" {
     disk_type    = "pd-ssd"
   }
 
+  dynamic "disk" {
+    for_each = var.use_local_ssd ? [1] : []
+    content {
+      device_name = "executor-pd"
+      interface = "SCSI"
+      disk_type = "local-ssd"
+      type = "SCRATCH"
+      disk_size_gb = 375
+    }
+  }
+
   network_interface {
     network    = var.network_id
     subnetwork = var.subnet_id
@@ -128,6 +139,8 @@ resource "google_compute_instance_template" "executor-instance-template" {
       "EXECUTOR_MAX_ACTIVE_TIME"            = var.max_active_time
       "EXECUTOR_USE_FIRECRACKER"            = var.use_firecracker
       "EXECUTOR_DOCKER_AUTH_CONFIG"         = var.docker_auth_config
+      "EXECUTOR_DOCKER_AUTH_CONFIG"         = var.docker_auth_config
+      "USE_LOCAL_SSD"                       = var.use_local_ssd
     }
   })
 

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -45,7 +45,6 @@ resource "random_id" "service_account" {
 resource "google_service_account" "sa" {
   account_id   = local.resource_values.service_account.account_id
   display_name = local.resource_values.service_account.display_name
-  labels       = local.resource_values.compute_instance_template.labels
 }
 
 resource "google_project_iam_member" "service_account_iam_log_writer" {
@@ -79,6 +78,8 @@ resource "google_compute_instance_template" "executor-instance-template" {
 
   # This is used for networking.
   tags = local.resource_values.compute_instance_template.tags
+
+  labels = local.resource_values.compute_instance_template.labels
 
   scheduling {
     automatic_restart = false

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -2,14 +2,14 @@ locals {
   prefix = var.resource_prefix != "" ? "${var.resource_prefix}-sourcegraph-" : "sourcegraph-"
 
   network_tags = var.randomize_resource_names ? [
-    substr("executors-${random_id.compute_instance_network_tag[0].hex}", 0, 64),
+    substr("${random_id.compute_instance_network_tag[0].hex}-executors", 0, 64),
     var.instance_tag,
     "executors"
   ] : []
 
   resource_values = {
     service_account = {
-      account_id   = var.randomize_resource_names ? substr("executors-${random_id.service_account[0].hex}", 0, 30) : "${substr(local.prefix, 0, 19)}executors"
+      account_id   = var.randomize_resource_names ? substr("${random_id.service_account[0].hex}-executors", 0, 30) : "${substr(local.prefix, 0, 19)}executors"
       display_name = var.randomize_resource_names ? "Service account for Sourcegraph executors" : "${var.resource_prefix}${var.resource_prefix != "" ? " " : ""}sourcegraph executors"
     }
     compute_instance_template = {
@@ -18,14 +18,14 @@ locals {
       labels      = var.randomize_resource_names ? merge({ executor_tag = var.instance_tag }, var.labels) : { executor_tag = var.instance_tag }
     }
     compute_instance_group_manager = {
-      name               = var.randomize_resource_names ? "executors-${random_id.compute_instance_group_executor[0].hex}" : "${local.prefix}executor"
-      base_instance_name = var.randomize_resource_names ? "executors-${random_id.compute_instance_group_executor[0].hex}" : "${local.prefix}executor"
+      name               = var.randomize_resource_names ? "${random_id.compute_instance_group_executor[0].hex}-executors" : "${local.prefix}executor"
+      base_instance_name = var.randomize_resource_names ? "${random_id.compute_instance_group_executor[0].hex}-executors" : "${local.prefix}executor"
     }
     compute_autoscaler = {
-      name = var.randomize_resource_names ? "executors-autoscaler-${random_id.compute_instance_group_executor[0].hex}" : "${local.prefix}executor-autoscaler"
+      name = var.randomize_resource_names ? "${random_id.compute_instance_group_executor[0].hex}-executors-autoscaler" : "${local.prefix}executor-autoscaler"
     }
     compute_firewall = {
-      name        = var.randomize_resource_names ? "executors-ssh-${random_id.firewall_rule_prefix[0].hex}" : "${local.prefix}executor-ssh-firewall"
+      name        = var.randomize_resource_names ? "${random_id.firewall_rule_prefix[0].hex}-executors-ssh" : "${local.prefix}executor-ssh-firewall"
       target_tags = var.randomize_resource_names ? local.network_tags : ["${local.prefix}executor"]
     }
   }

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -162,8 +162,6 @@ resource "google_compute_instance_group_manager" "executor" {
   name = local.resource_values.compute_instance_group_manager.name
   zone = var.zone
 
-  labels = local.resource_values.compute_instance_template.labels
-
   version {
     instance_template = google_compute_instance_template.executor-instance-template.id
     name              = "primary"
@@ -190,7 +188,6 @@ resource "google_compute_autoscaler" "executor-autoscaler" {
   name     = local.resource_values.compute_autoscaler.name
   zone     = var.zone
   target   = google_compute_instance_group_manager.executor.id
-  labels = local.resource_values.compute_instance_template.labels
 
   autoscaling_policy {
     min_replicas    = var.min_replicas

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -104,7 +104,7 @@ resource "google_compute_instance_template" "executor-instance-template" {
     for_each = var.use_local_ssd ? [1] : []
     content {
       device_name = "executor-pd"
-      interface = "SCSI"
+      interface = "NVME"
       disk_type = "local-ssd"
       type = "SCRATCH"
       disk_size_gb = 375

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -32,7 +32,7 @@ locals {
   }
 
   # if using local SSDs and using the default value of 100, lower it to 10, otherwise use the configured value either way.
-  boot_disk_size = var.use_local_ssd ? var.boot_disk_size == 100 ? 10 : var.boot_disk_size : var.boot_disk_size
+  boot_disk_size = var.use_local_ssd ? (var.boot_disk_size == 100 ? 10 : var.boot_disk_size) : var.boot_disk_size
 }
 
 # Fetch the google project set in the currently used provider.

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -106,12 +106,12 @@ resource "google_compute_instance_template" "executor-instance-template" {
   dynamic "disk" {
     for_each = var.use_local_ssd ? [1] : []
     content {
-      device_name = "executor-pd"
-      interface = "NVME"
-      disk_type = "local-ssd"
-      type = "SCRATCH"
+      device_name  = "executor-pd"
+      interface    = "NVME"
+      disk_type    = "local-ssd"
+      type         = "SCRATCH"
       disk_size_gb = 375
-      labels = local.resource_values.compute_instance_template.labels
+      labels       = local.resource_values.compute_instance_template.labels
     }
   }
 

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -30,8 +30,8 @@ locals {
     }
   }
 
-  # if using local SSDs and using the default value of 100, lower it to 20, otherwise use the configured value either way.
-  boot_disk_size = var.use_local_ssd ? var.boot_disk_size == 100 ? 20 : var.boot_disk_size : var.boot_disk_size
+  # if using local SSDs and using the default value of 100, lower it to 10, otherwise use the configured value either way.
+  boot_disk_size = var.use_local_ssd ? var.boot_disk_size == 100 ? 10 : var.boot_disk_size : var.boot_disk_size
 }
 
 # Fetch the google project set in the currently used provider.
@@ -138,7 +138,6 @@ resource "google_compute_instance_template" "executor-instance-template" {
       "EXECUTOR_NUM_TOTAL_JOBS"             = var.num_total_jobs
       "EXECUTOR_MAX_ACTIVE_TIME"            = var.max_active_time
       "EXECUTOR_USE_FIRECRACKER"            = var.use_firecracker
-      "EXECUTOR_DOCKER_AUTH_CONFIG"         = var.docker_auth_config
       "EXECUTOR_DOCKER_AUTH_CONFIG"         = var.docker_auth_config
       "USE_LOCAL_SSD"                       = var.use_local_ssd
     }

--- a/modules/executors/startup-script.sh.tpl
+++ b/modules/executors/startup-script.sh.tpl
@@ -30,6 +30,17 @@ if [ "$${EXECUTOR_DOCKER_REGISTRY_MIRROR}" != '' ]; then
   fi
 fi
 
+if [ "$${USE_LOCAL_SSD}" = "true" ]; then
+    echo "Using local SSD, preparing"
+    mkfs.ext4 -F /dev/executor-pd
+    mkdir -p /mnt/executor-pd/
+    mount /dev/executor-pd /mnt/executor-pd
+    rsync -xa /var/lib/firecracker /mnt/executor-pd
+    umount /mnt/executor-pd
+    rm -rf /mnt/executor-pd
+    mount /dev/executor-pd /var/lib/firecracker
+fi
+
 # Write the systemd environment file used by the executor service
 cat <<EOF >/etc/systemd/system/executor.env
 EXECUTOR_QUEUE_NAME="$${EXECUTOR_QUEUE_NAME}"

--- a/modules/executors/startup-script.sh.tpl
+++ b/modules/executors/startup-script.sh.tpl
@@ -32,13 +32,13 @@ fi
 
 if [ "$${USE_LOCAL_SSD}" = "true" ]; then
     echo "Using local SSD, preparing"
-    mkfs.ext4 -F /dev/disk/by-id/google-executor-pd
+    mkfs.ext4 -F /dev/disk/by-id/google-local-nvme-ssd-0
     mkdir -p /mnt/executor-pd/
-    mount /dev/disk/by-id/google-executor-pd /mnt/executor-pd
+    mount /dev/disk/by-id/google-local-nvme-ssd-0 /mnt/executor-pd
     rsync -xa /var/lib/firecracker/ /mnt/executor-pd
     umount /mnt/executor-pd
     rm -rf /mnt/executor-pd
-    mount -o discard,defaults,nobarrier /dev/disk/by-id/google-executor-pd /var/lib/firecracker
+    mount -o discard,defaults,nobarrier /dev/disk/by-id/google-local-nvme-ssd-0 /var/lib/firecracker
 fi
 
 # Write the systemd environment file used by the executor service

--- a/modules/executors/startup-script.sh.tpl
+++ b/modules/executors/startup-script.sh.tpl
@@ -38,7 +38,7 @@ if [ "$${USE_LOCAL_SSD}" = "true" ]; then
     rsync -xa /var/lib/firecracker/ /mnt/executor-pd
     umount /mnt/executor-pd
     rm -rf /mnt/executor-pd
-    mount /dev/disk/by-id/google-executor-pd /var/lib/firecracker
+    mount -o discard,defaults,nobarrier /dev/disk/by-id/google-executor-pd /var/lib/firecracker
 fi
 
 # Write the systemd environment file used by the executor service

--- a/modules/executors/startup-script.sh.tpl
+++ b/modules/executors/startup-script.sh.tpl
@@ -32,13 +32,13 @@ fi
 
 if [ "$${USE_LOCAL_SSD}" = "true" ]; then
     echo "Using local SSD, preparing"
-    mkfs.ext4 -F /dev/executor-pd
+    mkfs.ext4 -F /dev/disk/by-id/google-executor-pd
     mkdir -p /mnt/executor-pd/
-    mount /dev/executor-pd /mnt/executor-pd
-    rsync -xa /var/lib/firecracker /mnt/executor-pd
+    mount /dev/disk/by-id/google-executor-pd /mnt/executor-pd
+    rsync -xa /var/lib/firecracker/ /mnt/executor-pd
     umount /mnt/executor-pd
     rm -rf /mnt/executor-pd
-    mount /dev/executor-pd /var/lib/firecracker
+    mount /dev/disk/by-id/google-executor-pd /var/lib/firecracker
 fi
 
 # Write the systemd environment file used by the executor service

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -27,7 +27,7 @@ variable "machine_image" {
 
 variable "machine_type" {
   type        = string
-  default     = "n1-standard-4" // 4 vCPU, 15GB
+  default     = "c2-standard-8" // 8 vCPU, 32GB
   description = "Executor node machine type"
 }
 
@@ -90,7 +90,7 @@ variable "num_total_jobs" {
 
 variable "max_active_time" {
   type        = string
-  default     = "2h"
+  default     = "12h"
   description = "The maximum time that can be spent by the worker dequeueing records to be handled"
 }
 

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -31,7 +31,7 @@ variable "machine_image" {
 
 variable "machine_type" {
   type        = string
-  default     = "c2-standard-8" // 8 vCPU, 32GB
+  default     = "n1-standard-4" // 4 vCPU, 15GB
   description = "Executor node machine type"
 }
 
@@ -76,7 +76,7 @@ variable "queue_name" {
 
 variable "maximum_runtime_per_job" {
   type        = string
-  default     = "45m"
+  default     = "30m"
   description = "The maximum wall time that can be spent on a single job"
 }
 
@@ -94,7 +94,7 @@ variable "num_total_jobs" {
 
 variable "max_active_time" {
   type        = string
-  default     = "12h"
+  default     = "2h"
   description = "The maximum time that can be spent by the worker dequeueing records to be handled"
 }
 

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -72,7 +72,7 @@ variable "queue_name" {
 
 variable "maximum_runtime_per_job" {
   type        = string
-  default     = "30m"
+  default     = "45m"
   description = "The maximum wall time that can be spent on a single job"
 }
 

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -188,3 +188,9 @@ variable "randomize_resource_names" {
   type        = bool
   description = "Use randomized names for resources. Disable if you are upgrading existing executors that were deployed using the legacy naming conventions, unless you want to recreate executor resources on GCP."
 }
+
+variable "use_local_ssd" {
+  type        = bool
+  default     = false
+  description = "Use a local SSD for the data dir of ignite."
+}

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -3,19 +3,19 @@ locals {
 
   resource_values = {
     compute_network = {
-      name = var.randomize_resource_names ? "${random_id.network[0].hex}-executors" : "sourcegraph-executors"
+      name = var.randomize_resource_names ? "executors-${random_id.network[0].hex}" : "sourcegraph-executors"
     }
     compute_subnetwork = {
-      name = var.randomize_resource_names ? "${random_id.subnetwork[0].hex}-executors-subnet" : "sourcegraph-executors-subnet"
+      name = var.randomize_resource_names ? "executors-subnet-${random_id.subnetwork[0].hex}" : "sourcegraph-executors-subnet"
     }
     compute_router = {
-      name = var.randomize_resource_names ? "${random_id.router[0].hex}-executors" : "sourcegraph-executors-router"
+      name = var.randomize_resource_names ? "executors-${random_id.router[0].hex}" : "sourcegraph-executors-router"
     }
     compute_address = {
-      name = var.randomize_resource_names ? "${random_id.compute_address_nat[0].hex}-executors" : "sourcegraph-executors-router"
+      name = var.randomize_resource_names ? "executors-${random_id.compute_address_nat[0].hex}" : "sourcegraph-executors-router"
     }
     compute_router_nat = {
-      name = var.randomize_resource_names ? "${random_id.router_nat[0].hex}-executors" : "sourcegraph-executors-nat"
+      name = var.randomize_resource_names ? "executors-${random_id.router_nat[0].hex}" : "sourcegraph-executors-nat"
     }
   }
 }

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -3,19 +3,19 @@ locals {
 
   resource_values = {
     compute_network = {
-      name = var.randomize_resource_names ? "executors-${random_id.network[0].hex}" : "sourcegraph-executors"
+      name = var.randomize_resource_names ? "${random_id.network[0].hex}-executors" : "sourcegraph-executors"
     }
     compute_subnetwork = {
-      name = var.randomize_resource_names ? "executors-subnet-${random_id.subnetwork[0].hex}" : "sourcegraph-executors-subnet"
+      name = var.randomize_resource_names ? "${random_id.subnetwork[0].hex}-executors-subnet" : "sourcegraph-executors-subnet"
     }
     compute_router = {
-      name = var.randomize_resource_names ? "executors-${random_id.router[0].hex}" : "sourcegraph-executors-router"
+      name = var.randomize_resource_names ? "${random_id.router[0].hex}-executors" : "sourcegraph-executors-router"
     }
     compute_address = {
-      name = var.randomize_resource_names ? "executors-${random_id.compute_address_nat[0].hex}" : "sourcegraph-executors-router"
+      name = var.randomize_resource_names ? "${random_id.compute_address_nat[0].hex}-executors" : "sourcegraph-executors-router"
     }
     compute_router_nat = {
-      name = var.randomize_resource_names ? "executors-${random_id.router_nat[0].hex}" : "sourcegraph-executors-nat"
+      name = var.randomize_resource_names ? "${random_id.router_nat[0].hex}-executors" : "sourcegraph-executors-nat"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -22,8 +22,14 @@ variable "docker_mirror_machine_type" {
 
 variable "docker_mirror_boot_disk_size" {
   type        = number
-  default     = 32 // 32GB
+  default     = 64 // 64GB
   description = "Docker registry mirror node disk size in GB"
+}
+
+variable "docker_mirror_use_local_ssd" {
+  type        = bool
+  default     = false
+  description = "Use a local SSD for the data dir of the registry instead of a persistent disk. This will mean that the cache will reset after the instance is replaced! disk_size is also not honored when true."
 }
 
 variable "docker_mirror_http_access_cidr_ranges" {
@@ -50,8 +56,14 @@ variable "executor_machine_image" {
 
 variable "executor_machine_type" {
   type        = string
-  default     = "c2-standard-8" // 8 vCPU, 32GB
+  default     = "n1-standard-4" // 4 vCPU, 15GB
   description = "Executor node machine type"
+}
+
+variable "executor_use_local_ssd" {
+  type        = bool
+  default     = false
+  description = "Use a local SSD for the data dir of the registry instead of a persistent disk. This will mean that the cache will reset after the instance is replaced! disk_size is also not honored when true."
 }
 
 variable "executor_boot_disk_size" {
@@ -95,7 +107,7 @@ variable "executor_queue_name" {
 
 variable "executor_maximum_runtime_per_job" {
   type        = string
-  default     = "45m"
+  default     = "30m"
   description = "The maximum wall time that can be spent on a single job"
 }
 
@@ -113,7 +125,7 @@ variable "executor_num_total_jobs" {
 
 variable "executor_max_active_time" {
   type        = string
-  default     = "12h"
+  default     = "2h"
   description = "The maximum time that can be spent by the worker dequeueing records to be handled"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@ variable "docker_mirror_machine_type" {
 
 variable "docker_mirror_boot_disk_size" {
   type        = number
-  default     = 64 // 64GB
+  default     = 32 // 32GB
   description = "Docker registry mirror node disk size in GB"
 }
 
@@ -50,7 +50,7 @@ variable "executor_machine_image" {
 
 variable "executor_machine_type" {
   type        = string
-  default     = "n1-standard-4" // 4 vCPU, 15GB
+  default     = "c2-standard-8" // 8 vCPU, 32GB
   description = "Executor node machine type"
 }
 
@@ -95,7 +95,7 @@ variable "executor_queue_name" {
 
 variable "executor_maximum_runtime_per_job" {
   type        = string
-  default     = "30m"
+  default     = "45m"
   description = "The maximum wall time that can be spent on a single job"
 }
 
@@ -113,7 +113,7 @@ variable "executor_num_total_jobs" {
 
 variable "executor_max_active_time" {
   type        = string
-  default     = "2h"
+  default     = "12h"
   description = "The maximum time that can be spent by the worker dequeueing records to be handled"
 }
 


### PR DESCRIPTION
## Why local SSDs?

This PR adds support for mounting an SSD from the host directly, as opposed to having a larger boot SSD disk over iSCSI. A local SSD has higher bandwidth, lower latency, and much higher IOPS. This benefits the executors a lot - IO has always been the big bottleneck if doing multi-concurrency on a single host. Grafana says this new disk is about half as busy as the previous attempt.

*But we only need ~20GB plus collateral for each job 😢 😢*
True! But - and here comes the great part about this disk type:
Local SSDs are the only disk type (afaik) that support spot pricing as well - and we use spot instances :) 
Discounted price per GB for `ssd-pd`: $0.1581
Discounted price per GB for local SSD attached to spot instance: $0.04464

So one local SSD costs about $16.74 per month.
For the same price, we get 105.8GB of `ssd-pd` storage.
Guess what? We used to give the machines 100GB! Not because we need exactly 100GB, but because we needed the additional IOPS (which increase with every GB you allocate).
So this should be +- 0, at well improved performance. I've also seen this much more stable at higher concurrency per host - so potentially we could save even more.

Side-note: For the Cloud cluster, we always used much bigger disks, because we wanted auto indexing there to be as fast as possible. So on Cloud alone, we should save a good bunch. Also, this makes sure we use the same perf characteristics on both our largest instance and on managed instances, since we don't override this anymore.

### Performance comparison:

For a C2 instance with 8 VCPUs (our default) we get:

max 4000 IOPS read, 4000 IOPS write, 240MBps read, 240 MBps write
But per GB we allocate, we only get 30 IOPS, and 0.48 MBps of throughput.
At the 100 GB we use by default, that means merely 48MBps of throughput and 3000 IOPS.

With a local SSD, however, we get:
170,000 IOPS read, 90,000 IOPS write, and 660 MBps read, 350 MBps write.

### Question

We've arbitrarily picked 20GB as the maximum size for the firecracker VM disk - we might as well increase that default to 50GB and make executors work for even larger mono repos. This would incur zero additional cost for us when using local SSDs, if we go with local SSDs for MIs, too. 

### Test plan

Ran over the weekend on dotcom, no issues there.