### PR TITLE
Adjust default values

### DIFF
--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -7,7 +7,7 @@ locals {
   resource_values = {
     compute_disk = {
       name   = var.randomize_resource_names ? "${var.resource_prefix}-docker-mirror-${random_id.compute_disk_registry_data[0].hex}" : "docker-registry-data"
-      labels = var.randomize_resource_names ? var.labels : null
+      labels = var.randomize_resource_names ? merge({ executor_tag = "${var.instance_tag_prefix}-docker-mirror" }, var.labels) : { executor_tag = "${var.instance_tag_prefix}-docker-mirror" }
     }
     compute_instance = {
       name   = var.randomize_resource_names ? "${var.resource_prefix}-docker-mirror-${random_id.compute_instance_default[0].hex}" : "sourcegraph-executors-docker-registry-mirror"

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -81,9 +81,3 @@ variable "randomize_resource_names" {
   type        = bool
   description = "Use randomized names for resources. Disable if you are upgrading existing executors that were deployed using the legacy naming conventions, unless you want to recreate executor resources on GCP."
 }
-
-variable "use_local_ssd" {
-  type        = bool
-  default     = false
-  description = "Use a local SSD for the data dir of the registry instead of a persistent disk. This will mean that the cache will reset after the instance is replaced! disk_size is also not honored when true."
-}

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -21,13 +21,13 @@ variable "machine_image" {
 
 variable "machine_type" {
   type        = string
-  default     = "n1-standard-2" // 2 vCPU, 7.5GB
+  default     = "n2-standard-2" // 2 vCPU, 8GB
   description = "Docker registry mirror node machine type."
 }
 
 variable "boot_disk_size" {
   type        = number
-  default     = 32
+  default     = 10
   description = "Docker registry mirror node disk size in GB."
 }
 
@@ -80,4 +80,10 @@ variable "randomize_resource_names" {
   default     = false
   type        = bool
   description = "Use randomized names for resources. Disable if you are upgrading existing executors that were deployed using the legacy naming conventions, unless you want to recreate executor resources on GCP."
+}
+
+variable "use_local_ssd" {
+  type        = bool
+  default     = false
+  description = "Use a local SSD for the data dir of the registry instead of a persistent disk. This will mean that the cache will reset after the instance is replaced! disk_size is also not honored when true."
 }

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -31,7 +31,7 @@ variable "machine_image" {
 
 variable "machine_type" {
   type        = string
-  default     = "n1-standard-4" // 4 vCPU, 15GB
+  default     = "c2-standard-8" // 8 vCPU, 32GB
   description = "Executor node machine type"
 }
 
@@ -76,7 +76,7 @@ variable "queue_name" {
 
 variable "maximum_runtime_per_job" {
   type        = string
-  default     = "30m"
+  default     = "45m"
   description = "The maximum wall time that can be spent on a single job"
 }
 
@@ -94,7 +94,7 @@ variable "num_total_jobs" {
 
 variable "max_active_time" {
   type        = string
-  default     = "2h"
+  default     = "12h"
   description = "The maximum time that can be spent by the worker dequeueing records to be handled"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -16,13 +16,13 @@ variable "docker_mirror_machine_image" {
 
 variable "docker_mirror_machine_type" {
   type        = string
-  default     = "n1-standard-2" // 2 vCPU, 7.5GB
+  default     = "n2-standard-2" // 2 vCPU, 8GB
   description = "Docker registry mirror node machine type"
 }
 
 variable "docker_mirror_boot_disk_size" {
   type        = number
-  default     = 64 // 64GB
+  default     = 10 // 10 GB
   description = "Docker registry mirror node disk size in GB"
 }
 
@@ -50,7 +50,7 @@ variable "executor_machine_image" {
 
 variable "executor_machine_type" {
   type        = string
-  default     = "n1-standard-4" // 4 vCPU, 15GB
+  default     = "c2-standard-8" // 8 vCPU, 32GB
   description = "Executor node machine type"
 }
 
@@ -95,7 +95,7 @@ variable "executor_queue_name" {
 
 variable "executor_maximum_runtime_per_job" {
   type        = string
-  default     = "30m"
+  default     = "45m"
   description = "The maximum wall time that can be spent on a single job"
 }
 
@@ -113,7 +113,7 @@ variable "executor_num_total_jobs" {
 
 variable "executor_max_active_time" {
   type        = string
-  default     = "2h"
+  default     = "12h"
   description = "The maximum time that can be spent by the worker dequeueing records to be handled"
 }
 


### PR DESCRIPTION
This sets default values to the configuration we use at Sourcegraph. The current values were arbitrarily chosen and aren't validated to work well.

### Test plan

Ran over the weekend on dotcom.
