### PR TITLE
fixup: switch to `substr`

### DIFF
--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -1,5 +1,5 @@
 locals {
-  resource_prefix = (var.resource_prefix == "" || endswith(var.resource_prefix, "-")) ? var.resource_prefix : "${var.resource_prefix}-"
+  resource_prefix = (var.resource_prefix == "" || substr(var.resource_prefix, -1, -2) == "-") ? var.resource_prefix : "${var.resource_prefix}-"
 
   network_tags = var.randomize_resource_names ? [
     substr("${local.resource_prefix}docker-mirror-${random_id.compute_instance_network_tag[0].hex}", 0, 64),

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -1,5 +1,5 @@
 locals {
-  resource_prefix = (var.resource_prefix == "" || endswith(var.resource_prefix, "-")) ? var.resource_prefix : "${var.resource_prefix}-"
+  resource_prefix = (var.resource_prefix == "" || substr(var.resource_prefix, -1, -2) == "-") ? var.resource_prefix : "${var.resource_prefix}-"
   legacy_prefix   = local.resource_prefix != "" ? "${var.resource_prefix}-sourcegraph-" : "sourcegraph-"
 
   network_tags = var.randomize_resource_names ? [

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -1,7 +1,7 @@
 locals {
   ip_cidr = "10.0.1.0/24"
 
-  resource_prefix = (var.resource_prefix == "" || endswith(var.resource_prefix, "-")) ? var.resource_prefix : "${var.resource_prefix}-"
+  resource_prefix = (var.resource_prefix == "" || substr(var.resource_prefix, -1, -2) == "-") ? var.resource_prefix : "${var.resource_prefix}-"
 
   resource_values = {
     compute_network = {


### PR DESCRIPTION
- fixes https://github.com/sourcegraph/terraform-google-executors/pull/84 :facepalm:

Turns out `endswith` wasn't introduced until Terraform _1.3_?!

### Test plan
Plan works

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
