### PR TITLE
Fix terraform index access

### DIFF
--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -91,7 +91,7 @@ resource "google_compute_instance" "default" {
   dynamic "attached_disk" {
     for_each = var.use_local_ssd ? [] : [1]
     content {
-      source      = google_compute_disk.0.registry-data.self_link
+      source      = google_compute_disk.registry-data[0].self_link
       device_name = "registry-data"
       mode        = "READ_WRITE"
     }


### PR DESCRIPTION
Noticed this during the 4.5.1 upgrade 

Error message:
```
 Error: Invalid reference
│
│   on .terraform/modules/managed_instance.executors.docker-mirror/modules/docker-mirror/main.tf line 94, in resource "google_compute_instance" "default":
│   94:       source      = google_compute_disk.0.registry-data.self_link
│
│ A reference to a resource type must be followed by at least one attribute access, specifying the resource name.
```

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

Terraform is hard to test without actually applying it. 
I manually patched the providers for `rctest` and this worked
