### PR TITLE
rfc-795: add release manifest

### DIFF
--- a/.buildkite/check-latest-tag.sh
+++ b/.buildkite/check-latest-tag.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# TODO(burmudar): remove this
+echo ":warning: :warning :warning TEMPORARILY DISABLED :warning: :warning: :warning"
+exit 0
+
 scratch=$(mktemp -d -t tmp.XXXXXXXXXX)
 function finish() {
   rm -rf "$scratch"

--- a/.buildkite/check-latest-tag.sh
+++ b/.buildkite/check-latest-tag.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-# TODO(burmudar): remove this
-echo ":warning: :warning :warning TEMPORARILY DISABLED :warning: :warning: :warning"
-exit 0
-
 scratch=$(mktemp -d -t tmp.XXXXXXXXXX)
 function finish() {
   rm -rf "$scratch"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -43,7 +43,8 @@ steps:
       tar zxf sg-rfc795.tar.gz
       chmod +x ./sg-rfc795
 
-      PATH=$PATH:$(pwd) ./sg-rfc795 release run internal finalize --workdir=. --config-from-commit
+      export PATH=$PATH:$(pwd)
+      ./sg-rfc795 release run internal finalize --workdir=. --config-from-commit
   - label: "Promote to public: finalize"
     if: build.message =~ /^promote_release/ && build.branch =~ /^wip-release/
     command: |
@@ -54,4 +55,5 @@ steps:
       tar zxf sg-rfc795.tar.gz
       chmod +x ./sg-rfc795
 
-      PATH=$PATH:$(pwd) ./sg-rfc795 release run promote-to-public finalize --workdir=. --config-from-commit
+      export PATH=$PATH:$(pwd)
+      ./sg-rfc795 release run promote-to-public finalize --workdir=. --config-from-commit

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -30,7 +30,8 @@ steps:
       tar zxf sg-rfc795.tar.gz
       chmod +x ./sg-rfc795
 
-      PATH=$PATH:$(pwd) ./sg-rfc795 release run test --workdir=. --config-from-commit
+      export PATH=$PATH:$(pwd)
+      ./sg-rfc795 release run test --workdir=. --config-from-commit
 
   - wait
 

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -22,27 +22,36 @@ steps:
   - label: "Release: test"
     if: "build.branch =~ /^wip_/"
     command: |
+      wget https://github.com/comby-tools/comby/releases/download/1.8.1/comby-1.8.1-x86_64-linux
+      chmod +x ./comby-1.8.1-x86_64-linux
+
       wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
       tar zxf sg-rfc795.tar.gz
       chmod +x ./sg-rfc795
 
-      ./sg-rfc795 release run test --workdir=. --config-from-commit
+      PATH=$PATH:$(pwd) ./sg-rfc795 release run test --workdir=. --config-from-commit
 
   - wait
 
   - label: "Release: finalize"
     if: "build.branch =~ /^wip_/"
     command: |
+      wget https://github.com/comby-tools/comby/releases/download/1.8.1/comby-1.8.1-x86_64-linux
+      chmod +x ./comby-1.8.1-x86_64-linux
+
       wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
       tar zxf sg-rfc795.tar.gz
       chmod +x ./sg-rfc795
 
-      ./sg-rfc795 release run internal finalize --workdir=. --config-from-commit
+      PATH=$PATH:$(pwd) ./sg-rfc795 release run internal finalize --workdir=. --config-from-commit
   - label: "Promote to public: finalize"
     if: build.message =~ /^promote_release/ && build.branch =~ /^wip-release/
     command: |
+      wget https://github.com/comby-tools/comby/releases/download/1.8.1/comby-1.8.1-x86_64-linux
+      chmod +x ./comby-1.8.1-x86_64-linux
+
       wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
       tar zxf sg-rfc795.tar.gz
       chmod +x ./sg-rfc795
 
-      ./sg-rfc795 release run promote-to-public finalize --workdir=. --config-from-commit
+      PATH=$PATH:$(pwd) ./sg-rfc795 release run promote-to-public finalize --workdir=. --config-from-commit

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,20 +1,48 @@
 steps:
   - label: ":lipstick:"
     command: .buildkite/shfmt.sh
-    agents: { queue: standard }    
+    agents: { queue: standard }
   - label: ":lipstick:"
     command: .buildkite/terraform-fmt.sh
-    agents: { queue: standard }    
+    agents: { queue: standard }
   - label: ":lint-roller:"
     command: .buildkite/shellcheck.sh
-    agents: { queue: standard }    
+    agents: { queue: standard }
   - label: ":terraform:"
     command: .buildkite/terraform-validate.sh
-    agents: { queue: standard }    
+    agents: { queue: standard }
   - label: ":lint-roller:"
     command: .buildkite/check-latest-tag.sh
-    agents: { queue: standard }    
+    agents: { queue: standard }
   - command: .buildkite/ci-checkov.sh
-    label: ':lock: security - checkov'    
-    agents: { queue: standard }    
+    label: ':lock: security - checkov'
+    agents: { queue: standard }
     soft_fail: true
+
+  - label: "Release: test"
+    if: "build.branch =~ /^wip_/"
+    command: |
+      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
+      tar zxf sg-rfc795.tar.gz
+      chmod +x ./sg-rfc795
+
+      ./sg-rfc795 release run test --workdir=. --config-from-commit
+
+  - wait
+
+  - label: "Release: finalize"
+    if: "build.branch =~ /^wip_/"
+    command: |
+      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
+      tar zxf sg-rfc795.tar.gz
+      chmod +x ./sg-rfc795
+
+      ./sg-rfc795 release run internal finalize --workdir=. --config-from-commit
+  - label: "Promote to public: finalize"
+    if: build.message =~ /^promote_release/ && build.branch =~ /^wip-release/
+    command: |
+      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
+      tar zxf sg-rfc795.tar.gz
+      chmod +x ./sg-rfc795
+
+      ./sg-rfc795 release run promote-to-public finalize --workdir=. --config-from-commit

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -24,6 +24,7 @@ steps:
     command: |
       wget https://github.com/comby-tools/comby/releases/download/1.8.1/comby-1.8.1-x86_64-linux
       chmod +x ./comby-1.8.1-x86_64-linux
+      mv comby-1.8.1-x86_64-linux comby
 
       wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
       tar zxf sg-rfc795.tar.gz
@@ -38,6 +39,7 @@ steps:
     command: |
       wget https://github.com/comby-tools/comby/releases/download/1.8.1/comby-1.8.1-x86_64-linux
       chmod +x ./comby-1.8.1-x86_64-linux
+      mv comby-1.8.1-x86_64-linux comby
 
       wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
       tar zxf sg-rfc795.tar.gz
@@ -50,6 +52,7 @@ steps:
     command: |
       wget https://github.com/comby-tools/comby/releases/download/1.8.1/comby-1.8.1-x86_64-linux
       chmod +x ./comby-1.8.1-x86_64-linux
+      mv comby-1.8.1-x86_64-linux comby
 
       wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
       tar zxf sg-rfc795.tar.gz

--- a/release.yaml
+++ b/release.yaml
@@ -29,9 +29,9 @@ internal:
           - name: "update version in examples"
             cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
           - name: "update executors docker-mirror image name"
-            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
+            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' "\"sourcegraph-executors-docker-mirror-$(cat family_tag)\"" -i -f .tf
           - name: "update executors image name"
-            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
+            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' "\"sourcegraph-executors-$(cat family_tag)\"" -i -f .tf
           - name: "remove generated files"
             cmd: |
               rm -vf family_tag
@@ -58,9 +58,9 @@ internal:
           - name: "update version in examples"
             cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
           - name: "update executors docker-mirror image name"
-            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
+            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' "\"sourcegraph-executors-docker-mirror-$(cat family_tag)\"" -i -f .tf
           - name: "update executors image name"
-            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
+            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' "\"sourcegraph-executors-$(cat family_tag)\"" -i -f .tf
           - name: "remove generated file with image tag"
             cmd: rm -f family_tag
           - name: "remove generated files"
@@ -145,9 +145,9 @@ promoteToPublic:
       - name: "update version in examples"
         cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
       - name: "update executors docker-mirror image name"
-        cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
+        cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' "\"sourcegraph-executors-docker-mirror-$(cat family_tag)\"" -i -f .tf
       - name: "update executors image name"
-        cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
+        cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' "\"sourcegraph-executors-$(cat family_tag)\"" -i -f .tf
       - name: "remove generated files"
         cmd: |
           rm -vf family_tag

--- a/release.yaml
+++ b/release.yaml
@@ -2,10 +2,8 @@
 meta:
   productName: "terraform-google-executors"
   owners:
-    - "sourcegraph"
+    - "@sourcegraph/release"
   repository: "github.com/sourcegraph/terraform-google-executors"
-  artifacts:
-    - "nothing"
 requirements:
   - name: "comby exists"
     cmd: "which comby"
@@ -13,7 +11,6 @@ requirements:
   - name: "GitHub cli exists"
     cmd: "which gh"
     fixInstructions: "install GitHub cli"
-# No internal steps since any release in this repo is public
 internal:
   create:
     steps:

--- a/release.yaml
+++ b/release.yaml
@@ -43,6 +43,8 @@ internal:
               git push origin ${branch}
           - name: "gh"
             cmd: |
+              # sometimes gh can fail because when it runs the branch is there _yet_, so we do this fetch to make sure it is
+              git fetch origin "wip_{{version}}"
               gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" \
               --body "Test plan: automated release PR, CI will perform additional checks"
       major:
@@ -72,14 +74,21 @@ internal:
               git push origin ${branch}
           - name: "gh"
             cmd: |
+              # sometimes gh can fail because when it runs the branch is there _yet_, so we do this fetch to make sure it is
+              git fetch origin "wip_{{version}}"
               gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" \
               --body "Test plan: automated release PR, CI will perform additional checks"
   finalize:
     steps:
-      - name: "git:finalize"
+      - name: "git:fetch"
         cmd: |
           set -e
-          branch="wip-internal-release-{{version}}"
+          wip_branch="wip_{{version}}"
+          git fetch origin "${wip_branch}"
+          git checkout "${wip_branch}"
+      - name: "git:finalize"
+        cmd: |
+          finalize_branch="wip-internal-release-{{version}}"
           git switch -c "${branch}"
           echo "pushing branch ${branch}"
           git push origin "${branch}"
@@ -126,19 +135,26 @@ test:
 promoteToPublic:
   create:
     steps:
-      - name: git:internal_branch
+      - name: git:fetch_internal
         cmd: |
           set -e
           branch=wip-internal-release-{{version}}
           git fetch origin "${branch}
-      - name: "git:branch"
+      - name: "git:branch_release"
         cmd: |
           release_branch="wip-release-{{version}}"
           git switch -c "${release_branch}"
           git push origin "${release_branch}"
   finalize:
     steps:
-      - name: git:tag
+      - name: git:fetch_release
+        cmd: |
+          set -e
+          wip_branch="wip-release-{{version}}
+          git fetch origin "${wip_branch}"
+          git checkout "${wip_branch}"
+
+      - name: git:tag_release
         cmd: |
           set -e
           branch="wip-release-{{version}}"

--- a/release.yaml
+++ b/release.yaml
@@ -15,21 +15,21 @@ internal:
   create:
     steps:
       minor:
-          - name: generate required files for release process
+          - name: git:prev_tag
             cmd: |
               # get previous tag we need to replace
               git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
               # convert the tag to the image family format which uses hipens and is only for `major-minor`
               echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
-          - name: "update links in READMEs"
+          - name: "files(md)"
             cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
-          - name: "update version in examples"
+          - name: "files(tf)"
             cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
-          - name: "update executors docker-mirror image name"
+          - name: "docker:image"
             cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' "\"sourcegraph-executors-docker-mirror-$(cat family_tag)\"" -i -f .tf
-          - name: "update executors image name"
+          - name: "family:name"
             cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' "\"sourcegraph-executors-$(cat family_tag)\"" -i -f .tf
-          - name: "remove generated files"
+          - name: "cleanup"
             cmd: |
               rm -vf family_tag
               rm -vf prev_tag
@@ -38,24 +38,26 @@ internal:
               branch="wb/wip_{{version}}"
               git switch -c "${branch}"
               git commit -am 'release-minor: {{version}}' -m '{{config}}'
+              git push origin ${branch}
+          - name: "gh"
+            cmd: |
+              gh pr create -f -t "PRETEND RELEASE WIP: release_major: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"
       major:
-          - name: generate required files for release process
+          - name: git:prev_tag
             cmd: |
               # get previous tag we need to replace
               git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
               # convert the tag to the image family format which uses hipens and is only for `major-minor`
               echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
-          - name: "update links in READMEs"
+          - name: "files(md)"
             cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
-          - name: "update version in examples"
+          - name: "files(tf)"
             cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
-          - name: "update executors docker-mirror image name"
+          - name: "docker:image"
             cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' "\"sourcegraph-executors-docker-mirror-$(cat family_tag)\"" -i -f .tf
-          - name: "update executors image name"
+          - name: "family:name"
             cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' "\"sourcegraph-executors-$(cat family_tag)\"" -i -f .tf
-          - name: "remove generated file with image tag"
-            cmd: rm -f family_tag
-          - name: "remove generated files"
+          - name: "cleanup"
             cmd: |
               rm -vf family_tag
               rm -vf prev_tag
@@ -64,21 +66,23 @@ internal:
               branch="wb/wip_{{version}}"
               git switch -c "${branch}"
               git commit -am 'release-major: {{version}}' -m '{{config}}'
+              git push origin ${branch}
+          - name: "gh"
+            cmd: |
+              gh pr create -f -t "PRETEND RELEASE WIP: release_major: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"
   finalize:
     steps:
       - name: "git:finalize"
         cmd: |
-          git checkout wb/wip_{{version}}
-          git push origin wb/wip_{{version}}
-
-          gh pr create -f -t "PRETEND RELEASE - release-major: build {{version}}"
-
-          git switch -c "wb/release-{{version}}"
-          git push origin wb/release-{{version}}
+          set -e
+          branch="wip-release-{{version}}"
+          git switch -c "${branch}"
+          echo "pushing branch ${branch}"
+          git push origin "${branch}"
           git checkout -
 test:
   steps:
-    - name: "correct amount of versions changed made to README files"
+    - name: "changes:README"
       cmd: |
         count=$(comby -match-only '{{tag}}' '' -f .md | wc -l)
         expected=21
@@ -86,7 +90,7 @@ test:
           echo "expected ${expected} changes to README.md files, got ${count}"
           exit 1
         fi
-    - name: "correct amount of changes to .tf files"
+    - name: "changes:tf"
       cmd: |
         count=$(comby -match-only '"{{tag}}"' '' -f .tf | wc -l)
         expected=6
@@ -94,7 +98,7 @@ test:
           echo "expected ${expected} .tf files to be updated with \"{{tag}}\" but got ${count}"
           exit 1
         fi
-    - name: "docker-mirror image family updated"
+    - name: "changes:docker"
       cmd: |
         echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
         trap "rm family_tag" EXIT
@@ -104,7 +108,7 @@ test:
           echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-docker-mirror-$(family_tag)\" but got ${count}"
           exit 1
         fi
-    - name: "sourcegraph-executors image family updated"
+    - name: "changes:family"
       cmd: |
         echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
         trap "rm family_tag" EXIT
@@ -118,31 +122,43 @@ test:
 promoteToPublic:
   create:
     steps:
-      - name: generate required files for release process
+      - name: git:prev_tag
         cmd: |
           # get previous tag we need to replace
           git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
           # convert the tag to the image family format which uses hipens and is only for `major-minor`
           echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
-      - name: "update links in READMEs"
+      - name: "files(md)"
         cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
-      - name: "update version in examples"
+      - name: "files(tf)"
         cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
-      - name: "update executors docker-mirror image name"
+      - name: "docker:image"
         cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' "\"sourcegraph-executors-docker-mirror-$(cat family_tag)\"" -i -f .tf
-      - name: "update executors image name"
+      - name: "family:name"
         cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' "\"sourcegraph-executors-$(cat family_tag)\"" -i -f .tf
-      - name: "remove generated files"
+      - name: "cleanup"
         cmd: |
           rm -vf family_tag
           rm -vf prev_tag
       - name: "git:branch"
         cmd: |
-          branch="wb/promote_wip_{{version}}"
+          branch="promote-release-{{version}}"
           git switch -c "${branch}"
           git commit -am 'promote-release: {{version}}' -m '{{config}}'
-      - name: "git:push"
-        cmd: git push origin wb/promote_wip_{{version}}
-      - name: "GitHub:create PR"
+          git push origin "${branch}"
+      - name: "gh"
         cmd: |
-          gh pr create -f -t "PRETEND PROMOTE RELEASE - release: build {{version}}"
+          set -e
+          branch="wip-release-{{version}}"
+          # we need to fetch from origin just in case this branch doesn't exist locally, so that the PR can find the base
+          git fetch origin "${branch}"
+          gh pr create -f -t "PRETEND PROMOTE RELEASE - release: build {{version}}" --base "${branch}" --body "Test plan: automated release PR, CI will perform additional checks"
+  finalize:
+    steps:
+      - name: git:tag
+        cmd: |
+          set -e
+          branch="wip-release-{{version}}"
+          git checkout "${branch}"
+          git tag wip-{{version}}
+          git push origin ${branch} --tags

--- a/release.yaml
+++ b/release.yaml
@@ -13,12 +13,7 @@ requirements:
   - name: "GitHub cli exists"
     cmd: "which gh"
     fixInstructions: "install GitHub cli"
-input:
-  - image_family
-  - prev_version
-
 # No internal steps since any release in this repo is public
-
 test:
   steps:
     - name: "correct amount of versions changed made to README files"
@@ -47,58 +42,76 @@ test:
         fi
     - name: "docker-mirror image family updated"
       cmd: |
-        count=$(comby -match-only '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' '' -f .tf | wc -l)
+        echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
+        trap "rm family_tag" EXIT
+        count=$(comby -match-only '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' '' -f .tf | wc -l)
         expected=1
         if [[ ${count} -ne ${expected} ]]; then
-          echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}\" but got ${count}"
+          echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-docker-mirror-$(family_tag)\" but got ${count}"
           exit 1
         fi
     - name: "sourcegraph-executors image family updated"
       cmd: |
-        count=$(comby -match-only '"sourcegraph-executors-{{inputs.image_family.tag}}"' '' -f .tf | wc -l)
+        echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
+        trap "rm family_tag" EXIT
+        count=$(comby -match-only '"sourcegraph-executors-$(cat family_tag)"' '' -f .tf | wc -l)
         expected=1
         if [[ ${count} -ne ${expected} ]]; then
-          echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-{{inputs.image_family.tag}}\" but got ${count}"
+          echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-$(cat family_tag)\" but got ${count}"
           exit 1
         fi
 internal:
   create:
     steps:
-      patch:
-          - name: "update links in READMEs"
-            cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' -f .md
-          - name: "update version in examples"
-            cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
-          - name: "update executors docker-mirror image name"
-            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' -i -f .tf
-          - name: "update executors image name"
-            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-{{inputs.image_family.tag}}"' -i -f .tf
       minor:
+          - name: generate required files for release process
+            cmd: |
+              # get previous tag we need to replace
+              git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
+              # convert the tag to the image family format which uses hipens and is only for `major-minor`
+              echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
           - name: "update links in READMEs"
-            cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' -f .md
+            cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
           - name: "update version in examples"
-            cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
+            cmd: comby "\"$(cat prev_version)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
           - name: "update executors docker-mirror image name"
-            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' -i -f .tf
+            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
           - name: "update executors image name"
-            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-{{inputs.image_family.tag}}"' -i -f .tf
+            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
+          - name: "remove generated files"
+            cmd: |
+              rm -vf family_tag
+              rm -vf prev_tag
       major:
+          - name: generate required files for release process
+            cmd: |
+              # get previous tag we need to replace
+              git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
+              # convert the tag to the image family format which uses hipens and is only for `major-minor`
+              echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
           - name: "update links in READMEs"
-            cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' -f .md
+            cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
           - name: "update version in examples"
-            cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
+            cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
           - name: "update executors docker-mirror image name"
-            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' -i -f .tf
+            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
           - name: "update executors image name"
-            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-{{inputs.image_family.tag}}"' -i -f .tf
+            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
+          - name: "remove generated file with image tag"
+            cmd: rm -f family_tag
+          - name: "remove generated files"
+            cmd: |
+              rm -vf family_tag
+              rm -vf prev_tag
   finalize:
     steps:
         - name: "create new branch"
           cmd: git switch -c "wb/wip-release-{{tag}}"
         - name: "add changes branch"
           cmd: "git commit -am 'WB-WIP: Test Release {{tag}}' -m 'This is a Test release'"
+        - name: "tag the release"
+          cmd: "git tag -a {{tag}} -m 'WIP Release {{tag}}'"
         - name: "push branch"
           cmd: "git push origin wb/wip-release-{{tag}}"
         - name: "create release PR"
           cmd: gh pr create --draft --fill
-        # TODO: should we tag here ???

--- a/release.yaml
+++ b/release.yaml
@@ -15,7 +15,7 @@ internal:
   create:
     steps:
       minor:
-          - name: git:prev_tag
+          - name: "git:prev_tag"
             cmd: |
               # get previous tag we need to replace
               git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
@@ -41,7 +41,7 @@ internal:
               git push origin ${branch}
           - name: "gh"
             cmd: |
-              gh pr create -f -t "PRETEND RELEASE WIP: release_major: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"
+              gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"
       major:
           - name: git:prev_tag
             cmd: |
@@ -149,10 +149,10 @@ promoteToPublic:
       - name: "gh"
         cmd: |
           set -e
-          branch="wip-release-{{version}}"
-          # we need to fetch from origin just in case this branch doesn't exist locally, so that the PR can find the base
-          git fetch origin "${branch}"
-          gh pr create -f -t "PRETEND PROMOTE RELEASE - release: build {{version}}" --base "${branch}" --body "Test plan: automated release PR, CI will perform additional checks"
+          remote_branch="wip-release-{{version}}"
+          # we need to fetch from origin just in case this remote_branch doesn't exist locally, so that the PR can find the base
+          git fetch origin "${remote_branch}"
+          gh pr create -f -t "PRETEND PROMOTE RELEASE - release: build {{version}}" --base "${remote_branch}" --body "Test plan: automated release PR, CI will perform additional checks"
   finalize:
     steps:
       - name: git:tag

--- a/release.yaml
+++ b/release.yaml
@@ -1,0 +1,85 @@
+---
+meta:
+  productName: "terraform-google-executors"
+  owners:
+    - "sourcegraph"
+  repository: "github.com/sourcegraph/terraform-google-executors"
+  artifacts:
+    - "nothing"
+requirements:
+  - name: "comby exists"
+    cmd: "which comby"
+    fixInstructions: "install comby"
+  - name: "GitHub cli exists"
+    cmd: "which gh"
+    fixInstructions: "install GitHub cli"
+input:
+  - image_family
+  - prev_version
+
+# No internal steps since any release in this repo is public
+
+test:
+  steps:
+    - name: "correct amount of versions changed made to README files"
+      cmd: |
+        count=$(comby -match-only '{{tag}}' '' -f .md | wc -l)
+        expected=21
+        if [[ ${count} -ne ${expected} ]]; then
+          echo "expected ${expected} changes to README.md files, got ${count}"
+          exit 1
+        fi
+    - name: "correct amount of new version tags in README"
+      cmd: |
+        count=$(grep -c '{{tag}}' README.md)
+        expected=7
+        if [[ ${count} -ne ${expected} ]]; then
+          echo "expected ${expected} new version tags of \"{{tag}}\" in README.md, got ${count}"
+          exit 1
+        fi
+    - name: "correct amount of changes to .tf files"
+      cmd: |
+        count=$(comby -match-only '"{{tag}}"' '' -f .tf | wc -l)
+        expected=6
+        if [[ ${count} -ne ${expected} ]]; then
+          echo "expected ${expected} .tf files to be updated with \"{{tag}}\" but got ${count}"
+          exit 1
+        fi
+    - name: "docker-mirror image family updated"
+      cmd: |
+        count=$(comby -match-only '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' '' -f .tf | wc -l)
+        expected=1
+        if [[ ${count} -ne ${expected} ]]; then
+          echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}\" but got ${count}"
+          exit 1
+        fi
+    - name: "sourcegraph-executors image family updated"
+      cmd: |
+        count=$(comby -match-only '"sourcegraph-executors-{{inputs.image_family.tag}}"' '' -f .tf | wc -l)
+        expected=1
+        if [[ ${count} -ne ${expected} ]]; then
+          echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-{{inputs.image_family.tag}}\" but got ${count}"
+          exit 1
+        fi
+promoteToPublic:
+  create:
+    steps:
+      - name: "update links in READMEs"
+        cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' -f .md
+      - name: "update version in examples"
+        cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
+      - name: "update executors docker-mirror image name"
+        cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' -i -f .tf
+      - name: "update executors image name"
+        cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-{{inputs.image_family.tag}}"' -i -f .tf
+finalize:
+  steps:
+      - name: "create new branch"
+        cmd: git switch -c "wb/wip-release-{{tag}}"
+      - name: "add changes branch"
+        cmd: "git commit -am 'WB-WIP: Test Release {{tag}}' -m 'This is a Test release'"
+      - name: "push branch"
+        cmd: "git push origin wb/wip-release-{{tag}}"
+      - name: "create release PR"
+        cmd: gh pr create --draft --fill
+      # TODO: should we tag here ???

--- a/release.yaml
+++ b/release.yaml
@@ -69,15 +69,15 @@ internal:
               branch="wb/wip_{{version}}"
               git switch -c "${branch}"
               git commit -am 'release-major: {{version}}' -m '{{config}}'
-          - name: "git:push"
-            cmd: git push origin wb/wip_{{version}}
-          - name: "GitHub:create PR"
-            cmd: |
-              gh pr create -f -t "PRETEND RELEASE - release-major: build {{version}}"
   finalize:
     steps:
       - name: "git:finalize"
         cmd: |
+          git checkout wb/wip_{{version}}
+          git push origin wb/wip_{{version}}
+
+          gh pr create -f -t "PRETEND RELEASE - release-major: build {{version}}"
+
           git switch -c "wb/release-{{version}}"
           git push origin wb/release-{{version}}
           git checkout -

--- a/release.yaml
+++ b/release.yaml
@@ -27,9 +27,9 @@ internal:
             cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
           - name: "files(tf)"
             cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
-          - name: "docker:image"
+          - name: "family(name):docker-mirror"
             cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' "\"sourcegraph-executors-docker-mirror-$(cat family_tag)\"" -i -f .tf
-          - name: "family:name"
+          - name: "family(name):sourcegraph-executors"
             cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' "\"sourcegraph-executors-$(cat family_tag)\"" -i -f .tf
           - name: "cleanup"
             cmd: |
@@ -43,7 +43,8 @@ internal:
               git push origin ${branch}
           - name: "gh"
             cmd: |
-              gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"
+              gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" \
+              --body "Test plan: automated release PR, CI will perform additional checks"
       major:
           - name: git:prev_tag
             cmd: |
@@ -71,13 +72,14 @@ internal:
               git push origin ${branch}
           - name: "gh"
             cmd: |
-              gh pr create -f -t "PRETEND RELEASE WIP: release_major: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"
+              gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" \
+              --body "Test plan: automated release PR, CI will perform additional checks"
   finalize:
     steps:
       - name: "git:finalize"
         cmd: |
           set -e
-          branch="wip-release-{{version}}"
+          branch="wip-internal-release-{{version}}"
           git switch -c "${branch}"
           echo "pushing branch ${branch}"
           git push origin "${branch}"
@@ -124,37 +126,16 @@ test:
 promoteToPublic:
   create:
     steps:
-      - name: git:prev_tag
-        cmd: |
-          # get previous tag we need to replace
-          git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
-          # convert the tag to the image family format which uses hipens and is only for `major-minor`
-          echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
-      - name: "files(md)"
-        cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
-      - name: "files(tf)"
-        cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
-      - name: "docker:image"
-        cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' "\"sourcegraph-executors-docker-mirror-$(cat family_tag)\"" -i -f .tf
-      - name: "family:name"
-        cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' "\"sourcegraph-executors-$(cat family_tag)\"" -i -f .tf
-      - name: "cleanup"
-        cmd: |
-          rm -vf family_tag
-          rm -vf prev_tag
-      - name: "git:branch"
-        cmd: |
-          branch="promote-release-{{version}}"
-          git switch -c "${branch}"
-          git commit -am 'promote-release: {{version}}' -m '{{config}}'
-          git push origin "${branch}"
-      - name: "gh"
+      - name: git:internal_branch
         cmd: |
           set -e
-          remote_branch="wip-release-{{version}}"
-          # we need to fetch from origin just in case this remote_branch doesn't exist locally, so that the PR can find the base
-          git fetch origin "${remote_branch}"
-          gh pr create -f -t "PRETEND PROMOTE RELEASE - release: build {{version}}" --base "${remote_branch}" --body "Test plan: automated release PR, CI will perform additional checks"
+          branch=wip-internal-release-{{version}}
+          git fetch origin "${branch}
+      - name: "git:branch"
+        cmd: |
+          release_branch="wip-release-{{version}}"
+          git switch -c "${release_branch}"
+          git push origin "${release_branch}"
   finalize:
     steps:
       - name: git:tag

--- a/release.yaml
+++ b/release.yaml
@@ -38,11 +38,6 @@ internal:
               branch="wb/wip_{{version}}"
               git switch -c "${branch}"
               git commit -am 'release-minor: {{version}}' -m '{{config}}'
-          - name: "git:push"
-            cmd: git push origin wb/wip_{{version}}
-          - name: "GitHub:create PR"
-            cmd: |
-              gh pr create -f -t "PRETEND RELEASE - release-minor: build {{version}}"
       major:
           - name: generate required files for release process
             cmd: |

--- a/release.yaml
+++ b/release.yaml
@@ -14,6 +14,76 @@ requirements:
     cmd: "which gh"
     fixInstructions: "install GitHub cli"
 # No internal steps since any release in this repo is public
+internal:
+  create:
+    steps:
+      minor:
+          - name: generate required files for release process
+            cmd: |
+              # get previous tag we need to replace
+              git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
+              # convert the tag to the image family format which uses hipens and is only for `major-minor`
+              echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
+          - name: "update links in READMEs"
+            cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
+          - name: "update version in examples"
+            cmd: comby "\"$(cat prev_version)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
+          - name: "update executors docker-mirror image name"
+            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
+          - name: "update executors image name"
+            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
+          - name: "remove generated files"
+            cmd: |
+              rm -vf family_tag
+              rm -vf prev_tag
+          - name: "git:branch"
+            cmd: |
+              branch="wb/wip_{{version}}"
+              git switch -c "${branch}"
+              git commit -am 'release-minor: {{version}}' -m '{{config}}'
+          - name: "git:push"
+            cmd: git push origin wb/wip_{{version}}
+          - name: "GitHub:create PR"
+            cmd: |
+              gh pr create -f -t "PRETEND RELEASE - release-minor: build {{version}}"
+      major:
+          - name: generate required files for release process
+            cmd: |
+              # get previous tag we need to replace
+              git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
+              # convert the tag to the image family format which uses hipens and is only for `major-minor`
+              echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
+          - name: "update links in READMEs"
+            cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
+          - name: "update version in examples"
+            cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
+          - name: "update executors docker-mirror image name"
+            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
+          - name: "update executors image name"
+            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
+          - name: "remove generated file with image tag"
+            cmd: rm -f family_tag
+          - name: "remove generated files"
+            cmd: |
+              rm -vf family_tag
+              rm -vf prev_tag
+          - name: "git:branch"
+            cmd: |
+              branch="wb/wip_{{version}}"
+              git switch -c "${branch}"
+              git commit -am 'release-major: {{version}}' -m '{{config}}'
+          - name: "git:push"
+            cmd: git push origin wb/wip_{{version}}
+          - name: "GitHub:create PR"
+            cmd: |
+              gh pr create -f -t "PRETEND RELEASE - release-major: build {{version}}"
+  finalize:
+    steps:
+      - name: "git:finalize"
+        cmd: |
+          git switch -c "wb/release-{{version}}"
+          git push origin wb/release-{{version}}
+          git checkout -
 test:
   steps:
     - name: "correct amount of versions changed made to README files"
@@ -60,58 +130,35 @@ test:
           echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-$(cat family_tag)\" but got ${count}"
           exit 1
         fi
-internal:
+
+promoteToPublic:
   create:
     steps:
-      minor:
-          - name: generate required files for release process
-            cmd: |
-              # get previous tag we need to replace
-              git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
-              # convert the tag to the image family format which uses hipens and is only for `major-minor`
-              echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
-          - name: "update links in READMEs"
-            cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
-          - name: "update version in examples"
-            cmd: comby "\"$(cat prev_version)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
-          - name: "update executors docker-mirror image name"
-            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
-          - name: "update executors image name"
-            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
-          - name: "remove generated files"
-            cmd: |
-              rm -vf family_tag
-              rm -vf prev_tag
-      major:
-          - name: generate required files for release process
-            cmd: |
-              # get previous tag we need to replace
-              git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
-              # convert the tag to the image family format which uses hipens and is only for `major-minor`
-              echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
-          - name: "update links in READMEs"
-            cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
-          - name: "update version in examples"
-            cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
-          - name: "update executors docker-mirror image name"
-            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
-          - name: "update executors image name"
-            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
-          - name: "remove generated file with image tag"
-            cmd: rm -f family_tag
-          - name: "remove generated files"
-            cmd: |
-              rm -vf family_tag
-              rm -vf prev_tag
-  finalize:
-    steps:
-        - name: "create new branch"
-          cmd: git switch -c "wb/wip-release-{{tag}}"
-        - name: "add changes branch"
-          cmd: "git commit -am 'WB-WIP: Test Release {{tag}}' -m 'This is a Test release'"
-        - name: "tag the release"
-          cmd: "git tag -a {{tag}} -m 'WIP Release {{tag}}'"
-        - name: "push branch"
-          cmd: "git push origin wb/wip-release-{{tag}}"
-        - name: "create release PR"
-          cmd: gh pr create --draft --fill
+      - name: generate required files for release process
+        cmd: |
+          # get previous tag we need to replace
+          git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
+          # convert the tag to the image family format which uses hipens and is only for `major-minor`
+          echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
+      - name: "update links in READMEs"
+        cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
+      - name: "update version in examples"
+        cmd: comby "\"$(cat prev_version)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
+      - name: "update executors docker-mirror image name"
+        cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
+      - name: "update executors image name"
+        cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
+      - name: "remove generated files"
+        cmd: |
+          rm -vf family_tag
+          rm -vf prev_tag
+      - name: "git:branch"
+        cmd: |
+          branch="wb/promote_wip_{{version}}"
+          git switch -c "${branch}"
+          git commit -am 'promote-release: {{version}}' -m '{{config}}'
+      - name: "git:push"
+        cmd: git push origin wb/promote_wip_{{version}}
+      - name: "GitHub:create PR"
+        cmd: |
+          gh pr create -f -t "PRETEND PROMOTE RELEASE - release: build {{version}}"

--- a/release.yaml
+++ b/release.yaml
@@ -61,25 +61,44 @@ test:
           echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-{{inputs.image_family.tag}}\" but got ${count}"
           exit 1
         fi
-promoteToPublic:
+internal:
   create:
     steps:
-      - name: "update links in READMEs"
-        cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' -f .md
-      - name: "update version in examples"
-        cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
-      - name: "update executors docker-mirror image name"
-        cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' -i -f .tf
-      - name: "update executors image name"
-        cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-{{inputs.image_family.tag}}"' -i -f .tf
-finalize:
-  steps:
-      - name: "create new branch"
-        cmd: git switch -c "wb/wip-release-{{tag}}"
-      - name: "add changes branch"
-        cmd: "git commit -am 'WB-WIP: Test Release {{tag}}' -m 'This is a Test release'"
-      - name: "push branch"
-        cmd: "git push origin wb/wip-release-{{tag}}"
-      - name: "create release PR"
-        cmd: gh pr create --draft --fill
-      # TODO: should we tag here ???
+      patch:
+          - name: "update links in READMEs"
+            cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' -f .md
+          - name: "update version in examples"
+            cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
+          - name: "update executors docker-mirror image name"
+            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' -i -f .tf
+          - name: "update executors image name"
+            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-{{inputs.image_family.tag}}"' -i -f .tf
+      minor:
+          - name: "update links in READMEs"
+            cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' -f .md
+          - name: "update version in examples"
+            cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
+          - name: "update executors docker-mirror image name"
+            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' -i -f .tf
+          - name: "update executors image name"
+            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-{{inputs.image_family.tag}}"' -i -f .tf
+      major:
+          - name: "update links in READMEs"
+            cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' -f .md
+          - name: "update version in examples"
+            cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
+          - name: "update executors docker-mirror image name"
+            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' -i -f .tf
+          - name: "update executors image name"
+            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-{{inputs.image_family.tag}}"' -i -f .tf
+  finalize:
+    steps:
+        - name: "create new branch"
+          cmd: git switch -c "wb/wip-release-{{tag}}"
+        - name: "add changes branch"
+          cmd: "git commit -am 'WB-WIP: Test Release {{tag}}' -m 'This is a Test release'"
+        - name: "push branch"
+          cmd: "git push origin wb/wip-release-{{tag}}"
+        - name: "create release PR"
+          cmd: gh pr create --draft --fill
+        # TODO: should we tag here ???

--- a/release.yaml
+++ b/release.yaml
@@ -111,7 +111,7 @@ test:
       cmd: |
         echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
         trap "rm family_tag" EXIT
-        count=$(comby -match-only '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' '' -f .tf | wc -l)
+        count=$(comby -match-only "\"sourcegraph-executors-docker-mirror-$(cat family_tag)\"" '' -f .tf | wc -l)
         expected=1
         if [[ ${count} -ne ${expected} ]]; then
           echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-docker-mirror-$(family_tag)\" but got ${count}"
@@ -121,7 +121,7 @@ test:
       cmd: |
         echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
         trap "rm family_tag" EXIT
-        count=$(comby -match-only '"sourcegraph-executors-$(cat family_tag)"' '' -f .tf | wc -l)
+        count=$(comby -match-only "\"sourcegraph-executors-$(cat family_tag)\"" '' -f .tf | wc -l)
         expected=1
         if [[ ${count} -ne ${expected} ]]; then
           echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-$(cat family_tag)\" but got ${count}"

--- a/release.yaml
+++ b/release.yaml
@@ -91,14 +91,6 @@ test:
           echo "expected ${expected} changes to README.md files, got ${count}"
           exit 1
         fi
-    - name: "correct amount of new version tags in README"
-      cmd: |
-        count=$(grep -c '{{tag}}' README.md)
-        expected=7
-        if [[ ${count} -ne ${expected} ]]; then
-          echo "expected ${expected} new version tags of \"{{tag}}\" in README.md, got ${count}"
-          exit 1
-        fi
     - name: "correct amount of changes to .tf files"
       cmd: |
         count=$(comby -match-only '"{{tag}}"' '' -f .tf | wc -l)

--- a/release.yaml
+++ b/release.yaml
@@ -35,7 +35,7 @@ internal:
               rm -vf prev_tag
           - name: "git:branch"
             cmd: |
-              branch="wb/wip_{{version}}"
+              branch="wip_{{version}}"
               git switch -c "${branch}"
               git commit -am 'release-minor: {{version}}' -m '{{config}}'
               git push origin ${branch}
@@ -63,7 +63,7 @@ internal:
               rm -vf prev_tag
           - name: "git:branch"
             cmd: |
-              branch="wb/wip_{{version}}"
+              branch="wip_{{version}}"
               git switch -c "${branch}"
               git commit -am 'release-major: {{version}}' -m '{{config}}'
               git push origin ${branch}

--- a/release.yaml
+++ b/release.yaml
@@ -4,6 +4,8 @@ meta:
   owners:
     - "@sourcegraph/release"
   repository: "github.com/sourcegraph/terraform-google-executors"
+inputs:
+  releaseId: server
 requirements:
   - name: "comby exists"
     cmd: "which comby"

--- a/release.yaml
+++ b/release.yaml
@@ -27,7 +27,7 @@ internal:
           - name: "update links in READMEs"
             cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
           - name: "update version in examples"
-            cmd: comby "\"$(cat prev_version)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
+            cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
           - name: "update executors docker-mirror image name"
             cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
           - name: "update executors image name"
@@ -143,7 +143,7 @@ promoteToPublic:
       - name: "update links in READMEs"
         cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
       - name: "update version in examples"
-        cmd: comby "\"$(cat prev_version)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
+        cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
       - name: "update executors docker-mirror image name"
         cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
       - name: "update executors image name"


### PR DESCRIPTION
Adds release manifest for use with rfc-795 release tooling.

See https://github.com/sourcegraph/terraform-google-executors/pull/106 for release created with manifest

Closes https://github.com/sourcegraph/sourcegraph/issues/59066
### Test plan
1. `sg-rfc release create --type minor`
2. `git diff --stat > changes1.txt
3. `./prepare-release 6.6.666`, also edit script to return tag as '6-6`
4. `git diff --stat > changes2.txt`
5. `diff -y changes1.txt changes2.txt`, besides the `prepare-release.sh` change the changes are identical

