### PR TITLE
PRETEND RELEASE - release-minor: build v6.6.666

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ This repository provides a [Terraform module](https://learn.hashicorp.com/tutori
 
 This repository provides four submodules:
 
-1. The [executors module](https://registry.terraform.io/modules/sourcegraph/executors/google/5.2.0/submodules/executors) provisions compute resources for executors.
-2. The [docker-mirror module](https://registry.terraform.io/modules/sourcegraph/executors/google/5.2.0/submodules/docker-mirror) provisions a Docker registry pull-through cache.
-3. The [networking module](https://registry.terraform.io/modules/sourcegraph/executors/google/5.2.0/submodules/networking) provisions a network to be shared by the executor and Docker registry resources.
-4. The [credentials module](https://registry.terraform.io/modules/sourcegraph/executors/google/5.2.0/submodules/credentials) provisions credentials required by the Sourcegraph instance to enable observability and auto-scaling of executors.
+1. The [executors module](https://registry.terraform.io/modules/sourcegraph/executors/google/6.6.666/submodules/executors) provisions compute resources for executors.
+2. The [docker-mirror module](https://registry.terraform.io/modules/sourcegraph/executors/google/6.6.666/submodules/docker-mirror) provisions a Docker registry pull-through cache.
+3. The [networking module](https://registry.terraform.io/modules/sourcegraph/executors/google/6.6.666/submodules/networking) provisions a network to be shared by the executor and Docker registry resources.
+4. The [credentials module](https://registry.terraform.io/modules/sourcegraph/executors/google/6.6.666/submodules/credentials) provisions credentials required by the Sourcegraph instance to enable observability and auto-scaling of executors.
 
-The [multiple-executors example](https://github.com/sourcegraph/terraform-google-executors/blob/v5.2.0/examples/multiple-executors) uses the submodule directly to provision multiple executor resource groups performing different types of work. Follow this example if you are:
+The [multiple-executors example](https://github.com/sourcegraph/terraform-google-executors/blob/v6.6.666/examples/multiple-executors) uses the submodule directly to provision multiple executor resource groups performing different types of work. Follow this example if you are:
 1. Provisioning executors for use with multiple features (e.g., both [auto-indexing](https://docs.sourcegraph.com/code_intelligence/explanations/auto_indexing) and [server-side batch changes](https://docs.sourcegraph.com/batch_changes/explanations/server_side)), or
 2. Provisioning resources for multiple Sourcegraph instances (e.g., test, prod)
 
-This repository also provides a [root module](https://registry.terraform.io/modules/sourcegraph/executors/google/5.2.0) combining the executors, network, and docker-mirror resources into an easier to use package.
+This repository also provides a [root module](https://registry.terraform.io/modules/sourcegraph/executors/google/6.6.666) combining the executors, network, and docker-mirror resources into an easier to use package.
 
-The [single-executor example](https://github.com/sourcegraph/terraform-google-executors/blob/v5.2.0/examples/single-executor) uses the root module to provision a single executor type. Follow this example if you are deploying to a single Sourcegraph instance and using a single executors-backed feature.
+The [single-executor example](https://github.com/sourcegraph/terraform-google-executors/blob/v6.6.666/examples/single-executor) uses the root module to provision a single executor type. Follow this example if you are deploying to a single Sourcegraph instance and using a single executors-backed feature.
 
 ## Requirements
 

--- a/examples/multiple-executors/README.md
+++ b/examples/multiple-executors/README.md
@@ -1,6 +1,6 @@
 # Multiple executor example
 
-This example uses [networking](https://registry.terraform.io/modules/sourcegraph/executors/google/5.2.0/submodules/networking), [docker-mirror](https://registry.terraform.io/modules/sourcegraph/executors/google/5.2.0/submodules/docker-mirror), and [executors](https://registry.terraform.io/modules/sourcegraph/executors/google/5.2.0/submodules/executors) submodules that provision a network, a Docker registry mirror, and sets of resources running one or more types of executors.
+This example uses [networking](https://registry.terraform.io/modules/sourcegraph/executors/google/6.6.666/submodules/networking), [docker-mirror](https://registry.terraform.io/modules/sourcegraph/executors/google/6.6.666/submodules/docker-mirror), and [executors](https://registry.terraform.io/modules/sourcegraph/executors/google/6.6.666/submodules/executors) submodules that provision a network, a Docker registry mirror, and sets of resources running one or more types of executors.
 
 The following variables must be supplied:
 
@@ -10,4 +10,4 @@ The following variables must be supplied:
 
 If your deployment environment already has a Docker registry that can be used, only the `executor` submodule must be used (and references to the `networking` and `docker-mirror` modules can be dropped). The Docker registry mirror address can be supplied along with its containing network and subnetwork as pre-existing identifier literals.
 
-All of these module's variables are defined in [modules/networking/variables.tf](https://github.com/sourcegraph/terraform-google-executors/blob/v5.2.0/modules/networking/variables.tf), [modules/docker-mirror/variables.tf](https://github.com/sourcegraph/terraform-google-executors/blob/v5.2.0/modules/docker-mirror/variables.tf), and [modules/executors/variables.tf](https://github.com/sourcegraph/terraform-google-executors/blob/v5.2.0/modules/executors/variables.tf).
+All of these module's variables are defined in [modules/networking/variables.tf](https://github.com/sourcegraph/terraform-google-executors/blob/v6.6.666/modules/networking/variables.tf), [modules/docker-mirror/variables.tf](https://github.com/sourcegraph/terraform-google-executors/blob/v6.6.666/modules/docker-mirror/variables.tf), and [modules/executors/variables.tf](https://github.com/sourcegraph/terraform-google-executors/blob/v6.6.666/modules/executors/variables.tf).

--- a/examples/multiple-executors/main.tf
+++ b/examples/multiple-executors/main.tf
@@ -1,13 +1,13 @@
 module "networking" {
   source  = "sourcegraph/executors/google//modules/networking"
-  version = "5.2.0" # LATEST
+  version = "6.6.666" # LATEST
 
   region = local.region
 }
 
 module "docker-mirror" {
   source  = "sourcegraph/executors/google//modules/docker-mirror"
-  version = "5.2.0" # LATEST
+  version = "6.6.666" # LATEST
 
   zone                = local.zone
   network_id          = module.networking.network_id
@@ -17,7 +17,7 @@ module "docker-mirror" {
 
 module "executors-codeintel" {
   source  = "sourcegraph/executors/google//modules/executors"
-  version = "5.2.0" # LATEST
+  version = "6.6.666" # LATEST
 
   zone                                = local.zone
   network_id                          = module.networking.network_id
@@ -35,7 +35,7 @@ module "executors-codeintel" {
 
 module "executors-batches" {
   source  = "sourcegraph/executors/google//modules/executors"
-  version = "5.2.0" # LATEST
+  version = "6.6.666" # LATEST
 
   zone                                = local.zone
   network_id                          = module.networking.network_id

--- a/examples/private-single-executor/main.tf
+++ b/examples/private-single-executor/main.tf
@@ -1,6 +1,6 @@
 module "executors" {
   source  = "sourcegraph/executors/google"
-  version = "5.2.0" # LATEST
+  version = "6.6.666" # LATEST
 
   region                                       = local.region
   zone                                         = local.zone

--- a/examples/single-executor/README.md
+++ b/examples/single-executor/README.md
@@ -1,6 +1,6 @@
 # Single executor example
 
-This example uses the [root module](https://registry.terraform.io/modules/sourcegraph/executors/google/5.2.0) that provisions a network, a Docker registry mirror, and a set of resources to run _one_ type of executor. To provision more than one type of executor (multiple queues or multiple environments), see the following `multiple-executors` example.
+This example uses the [root module](https://registry.terraform.io/modules/sourcegraph/executors/google/6.6.666) that provisions a network, a Docker registry mirror, and a set of resources to run _one_ type of executor. To provision more than one type of executor (multiple queues or multiple environments), see the following `multiple-executors` example.
 
 The following variables must be supplied:
 
@@ -12,4 +12,4 @@ The following variables must be supplied:
 - `executor_metrics_environment_label`: The name of the target environment (e.g., `staging`, `prod`). This value must be the same as the `EXECUTOR_METRIC_ENVIRONMENT_LABEL` environment variable as described in [Configuring auto scaling](https://docs.sourcegraph.com/admin/deploy_executors#google).
 - `executor_instance_tag`: Compute instances are tagged by this value by the key `executor_tag`. We recommend this value take the form `{executor_queue_name}-{executor_metrics_environment_label}`. This value must be the same as `INSTANCE_TAG` as described in [Configuring observability](https://docs.sourcegraph.com/admin/deploy_executors#google-1).
 
-All of this module's variables are defined in [variables.tf](https://github.com/sourcegraph/terraform-google-executors/blob/v5.2.0/variables.tf).
+All of this module's variables are defined in [variables.tf](https://github.com/sourcegraph/terraform-google-executors/blob/v6.6.666/variables.tf).

--- a/examples/single-executor/main.tf
+++ b/examples/single-executor/main.tf
@@ -1,6 +1,6 @@
 module "executors" {
   source  = "sourcegraph/executors/google"
-  version = "5.2.0" # LATEST
+  version = "6.6.666" # LATEST
 
   region                                       = local.region
   zone                                         = local.zone

--- a/modules/docker-mirror/README.md
+++ b/modules/docker-mirror/README.md
@@ -2,4 +2,4 @@
 
 This module provides a hosted Docker registry pull-through cache to be used by [Sourcegraph executor](https://docs.sourcegraph.com/admin/executors). It is strongly recommended to deploy a Docker mirror as a cache to reduce rate limiting by the public [Docker Hub registry](https://hub.docker.com/). We have also seen deploying a Docker mirror in the same physical zone as the executors significantly decreased latencies during image pulls.
 
-When using the sibling [executors module](https://registry.terraform.io/modules/sourcegraph/executors/google/5.2.0/submodules/executors), the `network_id` and `subnet_id` values must match and the executor module `docker_registry_mirror` value should match `"http://${ip_address}:5000"` (where `ip_address` is this module's output).
+When using the sibling [executors module](https://registry.terraform.io/modules/sourcegraph/executors/google/6.6.666/submodules/executors), the `network_id` and `subnet_id` values must match and the executor module `docker_registry_mirror` value should match `"http://${ip_address}:5000"` (where `ip_address` is this module's output).

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -48,7 +48,7 @@ resource "google_compute_disk" "registry-data" {
 data "google_compute_image" "mirror_image" {
   count   = var.machine_image != "" ? 0 : 1
   project = "sourcegraph-ci"
-  family  = "sourcegraph-executors-docker-mirror-5-2"
+  family  = "sourcegraph-executors-docker-mirror-6-6"
 }
 
 resource "random_id" "compute_instance_default" {

--- a/modules/executors/README.md
+++ b/modules/executors/README.md
@@ -1,6 +1,6 @@
 # Executors module
 
-This module provides the resources to provision [Sourcegraph executor](https://docs.sourcegraph.com/admin/executors) compute resources on Google Cloud. For a high-level overview of the resources deployed by this module, see the [root module](https://registry.terraform.io/modules/sourcegraph/executors/google/5.2.0). This module includes the following resources:
+This module provides the resources to provision [Sourcegraph executor](https://docs.sourcegraph.com/admin/executors) compute resources on Google Cloud. For a high-level overview of the resources deployed by this module, see the [root module](https://registry.terraform.io/modules/sourcegraph/executors/google/6.6.666). This module includes the following resources:
 
 - Google compute instance template
 - Google compute group manager, and auto-scaler
@@ -9,4 +9,4 @@ This module provides the resources to provision [Sourcegraph executor](https://d
 
 This module does **not** automatically create networking or Docker mirror resources. The `network_id`, `subnet_id`, and `docker_registry_mirror` variables must be supplied explicitly with resources that have been previously created.
 
-This module is often used with the sibling modules that create [networking](https://registry.terraform.io/modules/sourcegraph/executors/google/5.2.0/submodules/networking) and [Docker mirror](https://registry.terraform.io/modules/sourcegraph/executors/google/5.2.0/submodules/docker-mirror) resources which can be shared by multiple instances of the executor module (listening to different queues or being deployed in a different environment).
+This module is often used with the sibling modules that create [networking](https://registry.terraform.io/modules/sourcegraph/executors/google/6.6.666/submodules/networking) and [Docker mirror](https://registry.terraform.io/modules/sourcegraph/executors/google/6.6.666/submodules/docker-mirror) resources which can be shared by multiple instances of the executor module (listening to different queues or being deployed in a different environment).

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -67,7 +67,7 @@ resource "google_project_iam_member" "service_account_iam_metric_writer" {
 data "google_compute_image" "executor_image" {
   count   = var.machine_image != "" ? 0 : 1
   project = "sourcegraph-ci"
-  family  = "sourcegraph-executors-5-2"
+  family  = "sourcegraph-executors-6-6"
 }
 
 resource "random_id" "compute_instance_network_tag" {

--- a/modules/networking/README.md
+++ b/modules/networking/README.md
@@ -1,6 +1,6 @@
 # Networking module
 
-This module provides the networking glue between the sibling [executors](https://registry.terraform.io/modules/sourcegraph/executors/google/5.2.0/submodules/executors) and [docker-mirror](https://registry.terraform.io/modules/sourcegraph/executors/google/5.2.0/submodules/docker-mirror) modules.
+This module provides the networking glue between the sibling [executors](https://registry.terraform.io/modules/sourcegraph/executors/google/6.6.666/submodules/executors) and [docker-mirror](https://registry.terraform.io/modules/sourcegraph/executors/google/6.6.666/submodules/docker-mirror) modules.
 
 This module is very simple, creating only a network and a subnet by default.
 

--- a/release.yaml
+++ b/release.yaml
@@ -29,9 +29,9 @@ internal:
           - name: "update version in examples"
             cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
           - name: "update executors docker-mirror image name"
-            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
+            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' "\"sourcegraph-executors-docker-mirror-$(cat family_tag)\"" -i -f .tf
           - name: "update executors image name"
-            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
+            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' "\"sourcegraph-executors-$(cat family_tag)\"" -i -f .tf
           - name: "remove generated files"
             cmd: |
               rm -vf family_tag
@@ -58,9 +58,9 @@ internal:
           - name: "update version in examples"
             cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
           - name: "update executors docker-mirror image name"
-            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
+            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' "\"sourcegraph-executors-docker-mirror-$(cat family_tag)\"" -i -f .tf
           - name: "update executors image name"
-            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
+            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' "\"sourcegraph-executors-$(cat family_tag)\"" -i -f .tf
           - name: "remove generated file with image tag"
             cmd: rm -f family_tag
           - name: "remove generated files"
@@ -145,9 +145,9 @@ promoteToPublic:
       - name: "update version in examples"
         cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
       - name: "update executors docker-mirror image name"
-        cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
+        cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' "\"sourcegraph-executors-docker-mirror-$(cat family_tag)\"" -i -f .tf
       - name: "update executors image name"
-        cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
+        cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' "\"sourcegraph-executors-$(cat family_tag)\"" -i -f .tf
       - name: "remove generated files"
         cmd: |
           rm -vf family_tag

--- a/release.yaml
+++ b/release.yaml
@@ -2,10 +2,8 @@
 meta:
   productName: "terraform-google-executors"
   owners:
-    - "sourcegraph"
+    - "@sourcegraph/release"
   repository: "github.com/sourcegraph/terraform-google-executors"
-  artifacts:
-    - "nothing"
 requirements:
   - name: "comby exists"
     cmd: "which comby"
@@ -13,7 +11,6 @@ requirements:
   - name: "GitHub cli exists"
     cmd: "which gh"
     fixInstructions: "install GitHub cli"
-# No internal steps since any release in this repo is public
 internal:
   create:
     steps:

--- a/release.yaml
+++ b/release.yaml
@@ -13,12 +13,7 @@ requirements:
   - name: "GitHub cli exists"
     cmd: "which gh"
     fixInstructions: "install GitHub cli"
-input:
-  - image_family
-  - prev_version
-
 # No internal steps since any release in this repo is public
-
 test:
   steps:
     - name: "correct amount of versions changed made to README files"
@@ -47,58 +42,76 @@ test:
         fi
     - name: "docker-mirror image family updated"
       cmd: |
-        count=$(comby -match-only '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' '' -f .tf | wc -l)
+        echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
+        trap "rm family_tag" EXIT
+        count=$(comby -match-only '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' '' -f .tf | wc -l)
         expected=1
         if [[ ${count} -ne ${expected} ]]; then
-          echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}\" but got ${count}"
+          echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-docker-mirror-$(family_tag)\" but got ${count}"
           exit 1
         fi
     - name: "sourcegraph-executors image family updated"
       cmd: |
-        count=$(comby -match-only '"sourcegraph-executors-{{inputs.image_family.tag}}"' '' -f .tf | wc -l)
+        echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
+        trap "rm family_tag" EXIT
+        count=$(comby -match-only '"sourcegraph-executors-$(cat family_tag)"' '' -f .tf | wc -l)
         expected=1
         if [[ ${count} -ne ${expected} ]]; then
-          echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-{{inputs.image_family.tag}}\" but got ${count}"
+          echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-$(cat family_tag)\" but got ${count}"
           exit 1
         fi
 internal:
   create:
     steps:
-      patch:
-          - name: "update links in READMEs"
-            cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' -f .md
-          - name: "update version in examples"
-            cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
-          - name: "update executors docker-mirror image name"
-            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' -i -f .tf
-          - name: "update executors image name"
-            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-{{inputs.image_family.tag}}"' -i -f .tf
       minor:
+          - name: generate required files for release process
+            cmd: |
+              # get previous tag we need to replace
+              git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
+              # convert the tag to the image family format which uses hipens and is only for `major-minor`
+              echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
           - name: "update links in READMEs"
-            cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' -f .md
+            cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
           - name: "update version in examples"
-            cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
+            cmd: comby "\"$(cat prev_version)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
           - name: "update executors docker-mirror image name"
-            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' -i -f .tf
+            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
           - name: "update executors image name"
-            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-{{inputs.image_family.tag}}"' -i -f .tf
+            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
+          - name: "remove generated files"
+            cmd: |
+              rm -vf family_tag
+              rm -vf prev_tag
       major:
+          - name: generate required files for release process
+            cmd: |
+              # get previous tag we need to replace
+              git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
+              # convert the tag to the image family format which uses hipens and is only for `major-minor`
+              echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
           - name: "update links in READMEs"
-            cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' -f .md
+            cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
           - name: "update version in examples"
-            cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
+            cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
           - name: "update executors docker-mirror image name"
-            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' -i -f .tf
+            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
           - name: "update executors image name"
-            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-{{inputs.image_family.tag}}"' -i -f .tf
+            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
+          - name: "remove generated file with image tag"
+            cmd: rm -f family_tag
+          - name: "remove generated files"
+            cmd: |
+              rm -vf family_tag
+              rm -vf prev_tag
   finalize:
     steps:
         - name: "create new branch"
           cmd: git switch -c "wb/wip-release-{{tag}}"
         - name: "add changes branch"
           cmd: "git commit -am 'WB-WIP: Test Release {{tag}}' -m 'This is a Test release'"
+        - name: "tag the release"
+          cmd: "git tag -a {{tag}} -m 'WIP Release {{tag}}'"
         - name: "push branch"
           cmd: "git push origin wb/wip-release-{{tag}}"
         - name: "create release PR"
           cmd: gh pr create --draft --fill
-        # TODO: should we tag here ???

--- a/release.yaml
+++ b/release.yaml
@@ -1,0 +1,85 @@
+---
+meta:
+  productName: "terraform-google-executors"
+  owners:
+    - "sourcegraph"
+  repository: "github.com/sourcegraph/terraform-google-executors"
+  artifacts:
+    - "nothing"
+requirements:
+  - name: "comby exists"
+    cmd: "which comby"
+    fixInstructions: "install comby"
+  - name: "GitHub cli exists"
+    cmd: "which gh"
+    fixInstructions: "install GitHub cli"
+input:
+  - image_family
+  - prev_version
+
+# No internal steps since any release in this repo is public
+
+test:
+  steps:
+    - name: "correct amount of versions changed made to README files"
+      cmd: |
+        count=$(comby -match-only '{{tag}}' '' -f .md | wc -l)
+        expected=21
+        if [[ ${count} -ne ${expected} ]]; then
+          echo "expected ${expected} changes to README.md files, got ${count}"
+          exit 1
+        fi
+    - name: "correct amount of new version tags in README"
+      cmd: |
+        count=$(grep -c '{{tag}}' README.md)
+        expected=7
+        if [[ ${count} -ne ${expected} ]]; then
+          echo "expected ${expected} new version tags of \"{{tag}}\" in README.md, got ${count}"
+          exit 1
+        fi
+    - name: "correct amount of changes to .tf files"
+      cmd: |
+        count=$(comby -match-only '"{{tag}}"' '' -f .tf | wc -l)
+        expected=6
+        if [[ ${count} -ne ${expected} ]]; then
+          echo "expected ${expected} .tf files to be updated with \"{{tag}}\" but got ${count}"
+          exit 1
+        fi
+    - name: "docker-mirror image family updated"
+      cmd: |
+        count=$(comby -match-only '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' '' -f .tf | wc -l)
+        expected=1
+        if [[ ${count} -ne ${expected} ]]; then
+          echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}\" but got ${count}"
+          exit 1
+        fi
+    - name: "sourcegraph-executors image family updated"
+      cmd: |
+        count=$(comby -match-only '"sourcegraph-executors-{{inputs.image_family.tag}}"' '' -f .tf | wc -l)
+        expected=1
+        if [[ ${count} -ne ${expected} ]]; then
+          echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-{{inputs.image_family.tag}}\" but got ${count}"
+          exit 1
+        fi
+promoteToPublic:
+  create:
+    steps:
+      - name: "update links in READMEs"
+        cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' -f .md
+      - name: "update version in examples"
+        cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
+      - name: "update executors docker-mirror image name"
+        cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' -i -f .tf
+      - name: "update executors image name"
+        cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-{{inputs.image_family.tag}}"' -i -f .tf
+finalize:
+  steps:
+      - name: "create new branch"
+        cmd: git switch -c "wb/wip-release-{{tag}}"
+      - name: "add changes branch"
+        cmd: "git commit -am 'WB-WIP: Test Release {{tag}}' -m 'This is a Test release'"
+      - name: "push branch"
+        cmd: "git push origin wb/wip-release-{{tag}}"
+      - name: "create release PR"
+        cmd: gh pr create --draft --fill
+      # TODO: should we tag here ???

--- a/release.yaml
+++ b/release.yaml
@@ -14,6 +14,76 @@ requirements:
     cmd: "which gh"
     fixInstructions: "install GitHub cli"
 # No internal steps since any release in this repo is public
+internal:
+  create:
+    steps:
+      minor:
+          - name: generate required files for release process
+            cmd: |
+              # get previous tag we need to replace
+              git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
+              # convert the tag to the image family format which uses hipens and is only for `major-minor`
+              echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
+          - name: "update links in READMEs"
+            cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
+          - name: "update version in examples"
+            cmd: comby "\"$(cat prev_version)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
+          - name: "update executors docker-mirror image name"
+            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
+          - name: "update executors image name"
+            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
+          - name: "remove generated files"
+            cmd: |
+              rm -vf family_tag
+              rm -vf prev_tag
+          - name: "git:branch"
+            cmd: |
+              branch="wb/wip_{{version}}"
+              git switch -c "${branch}"
+              git commit -am 'release-minor: {{version}}' -m '{{config}}'
+          - name: "git:push"
+            cmd: git push origin wb/wip_{{version}}
+          - name: "GitHub:create PR"
+            cmd: |
+              gh pr create -f -t "PRETEND RELEASE - release-minor: build {{version}}"
+      major:
+          - name: generate required files for release process
+            cmd: |
+              # get previous tag we need to replace
+              git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
+              # convert the tag to the image family format which uses hipens and is only for `major-minor`
+              echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
+          - name: "update links in READMEs"
+            cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
+          - name: "update version in examples"
+            cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
+          - name: "update executors docker-mirror image name"
+            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
+          - name: "update executors image name"
+            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
+          - name: "remove generated file with image tag"
+            cmd: rm -f family_tag
+          - name: "remove generated files"
+            cmd: |
+              rm -vf family_tag
+              rm -vf prev_tag
+          - name: "git:branch"
+            cmd: |
+              branch="wb/wip_{{version}}"
+              git switch -c "${branch}"
+              git commit -am 'release-major: {{version}}' -m '{{config}}'
+          - name: "git:push"
+            cmd: git push origin wb/wip_{{version}}
+          - name: "GitHub:create PR"
+            cmd: |
+              gh pr create -f -t "PRETEND RELEASE - release-major: build {{version}}"
+  finalize:
+    steps:
+      - name: "git:finalize"
+        cmd: |
+          git switch -c "wb/release-{{version}}"
+          git push origin wb/release-{{version}}
+          git checkout -
 test:
   steps:
     - name: "correct amount of versions changed made to README files"
@@ -60,58 +130,35 @@ test:
           echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-$(cat family_tag)\" but got ${count}"
           exit 1
         fi
-internal:
+
+promoteToPublic:
   create:
     steps:
-      minor:
-          - name: generate required files for release process
-            cmd: |
-              # get previous tag we need to replace
-              git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
-              # convert the tag to the image family format which uses hipens and is only for `major-minor`
-              echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
-          - name: "update links in READMEs"
-            cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
-          - name: "update version in examples"
-            cmd: comby "\"$(cat prev_version)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
-          - name: "update executors docker-mirror image name"
-            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
-          - name: "update executors image name"
-            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
-          - name: "remove generated files"
-            cmd: |
-              rm -vf family_tag
-              rm -vf prev_tag
-      major:
-          - name: generate required files for release process
-            cmd: |
-              # get previous tag we need to replace
-              git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
-              # convert the tag to the image family format which uses hipens and is only for `major-minor`
-              echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
-          - name: "update links in READMEs"
-            cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
-          - name: "update version in examples"
-            cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
-          - name: "update executors docker-mirror image name"
-            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
-          - name: "update executors image name"
-            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
-          - name: "remove generated file with image tag"
-            cmd: rm -f family_tag
-          - name: "remove generated files"
-            cmd: |
-              rm -vf family_tag
-              rm -vf prev_tag
-  finalize:
-    steps:
-        - name: "create new branch"
-          cmd: git switch -c "wb/wip-release-{{tag}}"
-        - name: "add changes branch"
-          cmd: "git commit -am 'WB-WIP: Test Release {{tag}}' -m 'This is a Test release'"
-        - name: "tag the release"
-          cmd: "git tag -a {{tag}} -m 'WIP Release {{tag}}'"
-        - name: "push branch"
-          cmd: "git push origin wb/wip-release-{{tag}}"
-        - name: "create release PR"
-          cmd: gh pr create --draft --fill
+      - name: generate required files for release process
+        cmd: |
+          # get previous tag we need to replace
+          git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
+          # convert the tag to the image family format which uses hipens and is only for `major-minor`
+          echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
+      - name: "update links in READMEs"
+        cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
+      - name: "update version in examples"
+        cmd: comby "\"$(cat prev_version)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
+      - name: "update executors docker-mirror image name"
+        cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
+      - name: "update executors image name"
+        cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-$(cat family_tag)"' -i -f .tf
+      - name: "remove generated files"
+        cmd: |
+          rm -vf family_tag
+          rm -vf prev_tag
+      - name: "git:branch"
+        cmd: |
+          branch="wb/promote_wip_{{version}}"
+          git switch -c "${branch}"
+          git commit -am 'promote-release: {{version}}' -m '{{config}}'
+      - name: "git:push"
+        cmd: git push origin wb/promote_wip_{{version}}
+      - name: "GitHub:create PR"
+        cmd: |
+          gh pr create -f -t "PRETEND PROMOTE RELEASE - release: build {{version}}"

--- a/release.yaml
+++ b/release.yaml
@@ -61,25 +61,44 @@ test:
           echo "expected ${expected} .tf files to be updated with \"sourcegraph-executors-{{inputs.image_family.tag}}\" but got ${count}"
           exit 1
         fi
-promoteToPublic:
+internal:
   create:
     steps:
-      - name: "update links in READMEs"
-        cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' -f .md
-      - name: "update version in examples"
-        cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
-      - name: "update executors docker-mirror image name"
-        cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' -i -f .tf
-      - name: "update executors image name"
-        cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-{{inputs.image_family.tag}}"' -i -f .tf
-finalize:
-  steps:
-      - name: "create new branch"
-        cmd: git switch -c "wb/wip-release-{{tag}}"
-      - name: "add changes branch"
-        cmd: "git commit -am 'WB-WIP: Test Release {{tag}}' -m 'This is a Test release'"
-      - name: "push branch"
-        cmd: "git push origin wb/wip-release-{{tag}}"
-      - name: "create release PR"
-        cmd: gh pr create --draft --fill
-      # TODO: should we tag here ???
+      patch:
+          - name: "update links in READMEs"
+            cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' -f .md
+          - name: "update version in examples"
+            cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
+          - name: "update executors docker-mirror image name"
+            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' -i -f .tf
+          - name: "update executors image name"
+            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-{{inputs.image_family.tag}}"' -i -f .tf
+      minor:
+          - name: "update links in READMEs"
+            cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' -f .md
+          - name: "update version in examples"
+            cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
+          - name: "update executors docker-mirror image name"
+            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' -i -f .tf
+          - name: "update executors image name"
+            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-{{inputs.image_family.tag}}"' -i -f .tf
+      major:
+          - name: "update links in READMEs"
+            cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' -f .md
+          - name: "update version in examples"
+            cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
+          - name: "update executors docker-mirror image name"
+            cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}"' -i -f .tf
+          - name: "update executors image name"
+            cmd: comby '"sourcegraph-executors-:[~\d+-\d+]"' '"sourcegraph-executors-{{inputs.image_family.tag}}"' -i -f .tf
+  finalize:
+    steps:
+        - name: "create new branch"
+          cmd: git switch -c "wb/wip-release-{{tag}}"
+        - name: "add changes branch"
+          cmd: "git commit -am 'WB-WIP: Test Release {{tag}}' -m 'This is a Test release'"
+        - name: "push branch"
+          cmd: "git push origin wb/wip-release-{{tag}}"
+        - name: "create release PR"
+          cmd: gh pr create --draft --fill
+        # TODO: should we tag here ???

--- a/release.yaml
+++ b/release.yaml
@@ -69,15 +69,15 @@ internal:
               branch="wb/wip_{{version}}"
               git switch -c "${branch}"
               git commit -am 'release-major: {{version}}' -m '{{config}}'
-          - name: "git:push"
-            cmd: git push origin wb/wip_{{version}}
-          - name: "GitHub:create PR"
-            cmd: |
-              gh pr create -f -t "PRETEND RELEASE - release-major: build {{version}}"
   finalize:
     steps:
       - name: "git:finalize"
         cmd: |
+          git co wb/wip_{{version}}
+          git push origin wb/wip_{{version}}
+
+          gh pr create -f -t "PRETEND RELEASE - release-major: build {{version}}"
+
           git switch -c "wb/release-{{version}}"
           git push origin wb/release-{{version}}
           git checkout -

--- a/release.yaml
+++ b/release.yaml
@@ -27,7 +27,7 @@ internal:
           - name: "update links in READMEs"
             cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
           - name: "update version in examples"
-            cmd: comby "\"$(cat prev_version)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
+            cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
           - name: "update executors docker-mirror image name"
             cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
           - name: "update executors image name"
@@ -143,7 +143,7 @@ promoteToPublic:
       - name: "update links in READMEs"
         cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' -f .md
       - name: "update version in examples"
-        cmd: comby "\"$(cat prev_version)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
+        cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
       - name: "update executors docker-mirror image name"
         cmd: comby '"sourcegraph-executors-docker-mirror-:[~\d+-\d+]"' '"sourcegraph-executors-docker-mirror-$(cat family_tag)"' -i -f .tf
       - name: "update executors image name"


### PR DESCRIPTION
- add release manifest
- define internal steps with finalise
- update release manifest to not use inputs
- update release manifest steps
- fix usage of prev_version instead of prev_tag
- fix family_tag usage
- fixup
- release-minor: v6.6.666
