### PR TITLE
Potentially fix issue with boot ordering

### DIFF
--- a/modules/executors/startup-script.sh.tpl
+++ b/modules/executors/startup-script.sh.tpl
@@ -11,6 +11,9 @@ DOCKER_REGISTRY_NODE_EXPORTER_URL_LINE=''
 
 export EXECUTOR_DOCKER_REGISTRY_MIRROR_URL="https://mirror.gcr.io"
 
+# Ensure the stored iptables rules are loaded:
+iptables-restore </etc/iptables/rules.v4
+
 # If a docker registry mirror is configured, create a startup script
 # that will configure docker to use the mirror. This requires writing
 # a docker configuration file and restarting the service.


### PR DESCRIPTION
It seems that recently docker started to run after the iptables-restore command, which then fails because it depends on some things to be created by docker I think.

This might fix our immediate issue by loading the chain manually again after boot.

Test plan: We'll need to upgrade an instance to use this. But running it manually on a broken one does make it start the executor service afterwards.